### PR TITLE
Attempt mkdir -p libs/$SELF before copying into it

### DIFF
--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -26,6 +26,7 @@ git submodule update -q --init libs/headers
 git submodule update -q --init tools/boost_install
 git submodule update -q --init tools/boostdep
 git submodule update -q --init tools/build
+mkdir -p libs/$SELF
 cp -r $TRAVIS_BUILD_DIR/* libs/$SELF
 export BOOST_ROOT="`pwd`"
 export PATH="`pwd`":$PATH


### PR DESCRIPTION
Projects either proposed or working toward proposal for inclusion in boostorg/, `cp -r $TRAVIS_BUILD_DIR/* libs/$SELF` will fail since `libs/$SELF` won't exist.