### PR TITLE
Replace $TRAVIS_BRANCH with $BOOST_BRANCH for Boost checkout

### DIFF
--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -20,7 +20,12 @@ cd ..
 if [ "$SELF" == "interval" ]; then
     export SELF=numeric/interval
 fi
-git clone -b $TRAVIS_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
+if [ "$TRAVIS_BRANCH" == "master" ]; then
+    export BOOST_BRANCH="master"
+else
+    export BOOST_BRANCH="develop"
+fi
+git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
 cd boost-root
 git submodule update -q --init libs/headers
 git submodule update -q --init tools/boost_install


### PR DESCRIPTION
Since $TRAVIS_BRANCH reflects the actual branch being built (which could be something other than "master" or "develop"), git checkout of boost will fail if $TRAVIS_BRANCH is indeed not "master" or "develop".