### PR TITLE
Use $TRAVIS_REPO_SLUG and $BOOST_BRANCH

### DIFF
--- a/ci/travis/coverity.sh
+++ b/ci/travis/coverity.sh
@@ -22,7 +22,7 @@ set -ex
 pushd /tmp
 if [[ "$1" != "--skipdownload" ]]; then
   rm -rf coverity_tool.tgz cov-analysis*
-  wget -q https://scan.coverity.com/download/linux64 --post-data "token=$COVERITY_SCAN_TOKEN&project=boostorg/$SELF" -O coverity_tool.tgz
+  wget -q https://scan.coverity.com/download/linux64 --post-data "token=$COVERITY_SCAN_TOKEN&project=$TRAVIS_REPO_SLUG" -O coverity_tool.tgz
   tar xzf coverity_tool.tgz
 fi
 COVBIN=$(echo $(pwd)/cov-analysis*/bin)
@@ -36,7 +36,7 @@ tar cJf cov-int.tar.xz cov-int/
 curl --form token="$COVERITY_SCAN_TOKEN" \
      --form email="$COVERITY_SCAN_NOTIFICATION_EMAIL" \
      --form file=@cov-int.tar.xz \
-     --form version="$TRAVIS_BRANCH" \
-     --form description="boostorg/$SELF" \
-     https://scan.coverity.com/builds?project="boostorg/$SELF"
+     --form version="$BOOST_BRANCH" \
+     --form description="$TRAVIS_REPO_SLUG" \
+     https://scan.coverity.com/builds?project="$TRAVIS_REPO_SLUG"
 


### PR DESCRIPTION
1. `$BOOST_BRANCH` replaces `$TRAVIS_BRANCH` for `form version` item. This is entirely dependent on PR #5, but here for consistency.

2. `$TRAVIS_REPO_SLUG` in this PR replaces `boostorg/$SELF`; `$TRAVIS_REPO_SLUG` resolves to `owner_name/repo_name` according to [Travis-CI Environment Variables](https://docs.travis-ci.com/user/environment-variables). For `boostorg` repos, I believe this will be seamless. For not-yet `boostorg` repos, they can still use Boost-CI and have their projects resolve properly for the `project` and `form description` items.