### PR TITLE
Use %BOOST_BRANCH% instead of %APPVEYOR_REPO_BRANCH%

### DIFF
--- a/ci/appveyor/install.bat
+++ b/ci/appveyor/install.bat
@@ -1,6 +1,6 @@
 @ECHO ON
 cd .. || EXIT /B
-git clone -b %APPVEYOR_REPO_BRANCH% --depth 1 https://github.com/boostorg/boost.git boost-root || EXIT /B
+git clone -b %BOOST_BRANCH% --depth 1 https://github.com/boostorg/boost.git boost-root || EXIT /B
 cd boost-root || EXIT /B
 git submodule update -q --init libs/headers || EXIT /B
 git submodule update -q --init tools/boost_install || EXIT /B

--- a/templates/appveyor.yml
+++ b/templates/appveyor.yml
@@ -108,6 +108,8 @@ environment:
       SCRIPT: ci\appveyor\mingw.bat
 
 install:
+  - set BOOST_BRANCH=develop
+  - if "%APPVEYOR_REPO_BRANCH%" == "master" set BOOST_BRANCH=master
   - set SELF=%APPVEYOR_PROJECT_NAME:-=_%
   - git clone https://github.com/boostorg/boost-ci.git C:\boost-ci
   - xcopy /s /e /q /i C:\boost-ci\ci .\ci


### PR DESCRIPTION
This is analogous to PR #5 (regarding non-"master/non-"develop" branches), just for Appveyor.