### PR TITLE
If no user-specified GCOV then derive it from B2_TOOLSET

### DIFF
--- a/ci/travis/codecov.sh
+++ b/ci/travis/codecov.sh
@@ -16,7 +16,12 @@ set -ex
 . ci/travis/enforce.sh
 
 if [ -z "$GCOV" ]; then
-    GCOV=gcov-7
+    if [ "${B2_TOOLSET%%-*}" == "gcc" ]; then
+        ver="${B2_TOOLSET#*-}"
+        GCOV=gcov-${ver}
+    else
+        GCOV=gcov-7 # default
+    fi
 fi
 
 B2_VARIANT=debug


### PR DESCRIPTION
Follows suggestion in https://github.com/boostorg/boost-ci/pull/8#issuecomment-488819900