### PR TITLE
Add GCC 4.9 build job to Travis CI

### DIFF
--- a/templates/.travis.yml
+++ b/templates/.travis.yml
@@ -91,6 +91,7 @@ anchors:
                                            "libstdc++-8-dev" ], sources: [ "llvm-toolchain-xenial-8",
                                                                            "ubuntu-toolchain-r-test"   ] } }
   gcc-48:   &gcc-48   { apt: { packages: [ "g++-4.8"         ]                                           } }
+  gcc-49:   &gcc-49   { apt: { packages: [ "g++-4.9"         ]                                           } }
   gcc-5:    &gcc-5    { apt: { packages: [ "g++-5"           ]                                           } }
   gcc-6:    &gcc-6    { apt: { packages: [ "g++-6"           ], sources: [ "ubuntu-toolchain-r-test"   ] } }
   gcc-7:    &gcc-7    { apt: { packages: [ "g++-7"           ], sources: [ "ubuntu-toolchain-r-test"   ] } }
@@ -104,6 +105,7 @@ jobs:
   include:
     # libstdc++
     - { os: "linux", env: [ "B2_TOOLSET=gcc-4.8",     "B2_CXXSTD=03,11"    ], addons: *gcc-48    }
+    - { os: "linux", env: [ "B2_TOOLSET=gcc-4.9",     "B2_CXXSTD=03,11"    ], addons: *gcc-49    }
     - { os: "linux", env: [ "B2_TOOLSET=gcc-5",       "B2_CXXSTD=11"       ], addons: *gcc-5     }
     - { os: "linux", env: [ "B2_TOOLSET=gcc-6",       "B2_CXXSTD=11,14"    ], addons: *gcc-6     }
     - { os: "linux", env: [ "B2_TOOLSET=gcc-7",       "B2_CXXSTD=11,14,17" ], addons: *gcc-7     }


### PR DESCRIPTION
GCC 4.9 is the first version with reasonable support for C++11.
For example, Boost.MP11 originally only supported GCC 4.9+ but later Peter added (partial) support for GCC 4.7/4.8.
There are known C++11 bugs in GCC 4.8 that nobody will fix.