### PR TITLE
Extend list of branches allowed to build

### DIFF
--- a/templates/.travis.yml
+++ b/templates/.travis.yml
@@ -50,6 +50,9 @@ branches:
   only:
     - develop
     - master
+    - feature/*
+    - fix/*
+    - pr/*
 
 script:
   - cd $BOOST_ROOT/libs/$SELF

--- a/templates/appveyor.yml
+++ b/templates/appveyor.yml
@@ -27,6 +27,9 @@ branches:
   only:
     - develop
     - master
+    - feature/*
+    - fix/*
+    - pr/*
 
 matrix:
   # Adding MAYFAIL to any matrix job allows it to fail but the build stays green:


### PR DESCRIPTION
Having a simple common convention in place will allow one off to test their contributions with Ci services using their own accounts prior submitting as PR for testing as part of boostorg/

-----

Then, maintainers of libraries using the boost-ci infrastructure could add note to their README.md or CONTRIBUTING.md files:

> In order to enable CI builds for your topic branches, name your branches using one of the recognised prefixes: `feature/`, `fix/` or `pr/`

/cc @Mike-Devel, @pdimov 