### PR TITLE
Fix Bash syntax for clang globs matching

### DIFF
--- a/ci/azure-pipelines/install.sh
+++ b/ci/azure-pipelines/install.sh
@@ -98,7 +98,7 @@ if [ "${B2_TOOLSET%%-*}" == "clang" ]; then
     # Additionally, if B2_TOOLSET is clang variant but CXX is set to g++
     # (it is on Linux images) then boost build silently ignores B2_TOOLSET and
     # uses CXX instead
-    if [ "${CXX}" != "clang"* ]; then
+    if [[ "${CXX}" != "clang"* ]]; then
         echo "CXX is set to ${CXX} in this environment which would override"
         echo "the setting of B2_TOOLSET=clang, therefore we clear CXX here."
         export CXX=

--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -61,7 +61,7 @@ if [ "${B2_TOOLSET%%-*}" == "clang" ]; then
     # Additionally, if B2_TOOLSET is clang variant but CXX is set to g++
     # (it is on Travis CI) then boost build silently ignores B2_TOOLSET and
     # uses CXX instead
-    if [ "${CXX}" != "clang"* ]; then
+    if [[ "${CXX}" != "clang"* ]]; then
         echo "CXX is set to ${CXX} in this environment which would override"
         echo "the setting of B2_TOOLSET=clang, therefore we clear CXX here."
         export CXX=


### PR DESCRIPTION
Since `[ .. ]` can't match globs, the condition was broken.
Use `[[ .. ]]` instead.
See https://github.com/koalaman/shellcheck/wiki/SC2081

------

/cc @sdkrystian This should also fix the issue you revealed with the Azure Pipelines template broken for the clang jobs.