### PR TITLE
Replace non-standard `which` with built-i `command -v`

### DIFF
--- a/ci/azure-pipelines/install.sh
+++ b/ci/azure-pipelines/install.sh
@@ -92,8 +92,8 @@ if [ "${B2_TOOLSET%%-*}" == "clang" ]; then
     export PATH=/usr/lib/llvm-${ver}/bin:$PATH
     ls -ls /usr/lib/llvm-${ver}/bin || true
     hash -r || true
-    which clang || true
-    which clang++ || true
+    command -v clang || true
+    command -v clang++ || true
 
     # Additionally, if B2_TOOLSET is clang variant but CXX is set to g++
     # (it is on Linux images) then boost build silently ignores B2_TOOLSET and
@@ -124,4 +124,4 @@ if ! command -v ${CXX}; then
     echo "WARNING: Compiler ${CXX} was not installed properly"
     #exit 1
 fi
-echo "using ${B2_TOOLSET} : : $(which ${CXX}) : ${B2_CXXFLAGS} ;" > ${HOME}/user-config.jam
+echo "using ${B2_TOOLSET} : : $(command -v ${CXX}) : ${B2_CXXFLAGS} ;" > ${HOME}/user-config.jam

--- a/ci/travis/codecov.sh
+++ b/ci/travis/codecov.sh
@@ -33,7 +33,7 @@ rm -rf /tmp/lcov
 pushd /tmp
 git clone -b v1.14 https://github.com/linux-test-project/lcov.git
 export PATH=/tmp/lcov/bin:$PATH
-which lcov
+command -v lcov
 lcov --version
 popd
 

--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -55,8 +55,8 @@ if [ "${B2_TOOLSET%%-*}" == "clang" ]; then
     export PATH=/usr/lib/llvm-${ver}/bin:$PATH
     ls -ls /usr/lib/llvm-${ver}/bin || true
     hash -r || true
-    which clang || true
-    which clang++ || true
+    command -v clang || true
+    command -v clang++ || true
 
     # Additionally, if B2_TOOLSET is clang variant but CXX is set to g++
     # (it is on Travis CI) then boost build silently ignores B2_TOOLSET and

--- a/templates/azure-pipelines.yml
+++ b/templates/azure-pipelines.yml
@@ -284,7 +284,7 @@ stages:
         set -e
         uname -a
         sudo xcode-select -switch ${XCODE_APP}
-        which clang++
+        command -v clang++
 
         git clone --branch master https://github.com/boostorg/boost-ci.git boost-ci
         cp -pr boost-ci/ci boost-ci/.codecov.yml .


### PR DESCRIPTION
The `command -v` is a POSIX standard builtin.
https://github.com/koalaman/shellcheck/wiki/SC2230

Although that is not an issue on Linux flavours, checks using empty
string (e.g. for `CXX`) on macOS output.

```
usage: which [-as] program ...
```

what displays the non-standard behaviour of `which`. Annoyance.