### PR TITLE
Make codecov.sh location independent

### DIFF
--- a/ci/travis/codecov.sh
+++ b/ci/travis/codecov.sh
@@ -13,7 +13,7 @@
 
 set -ex
 
-. ci/travis/enforce.sh
+. $(dirname "${BASH_SOURCE[0]}")/enforce.sh
 
 if [ -z "$GCOV" ]; then
     if [ "${B2_TOOLSET%%-*}" == "gcc" ]; then
@@ -38,7 +38,7 @@ lcov --version
 popd
 
 B2_VARIANT=variant=debug
-ci/travis/build.sh cxxflags=--coverage linkflags=--coverage 
+$(dirname "${BASH_SOURCE[0]}")/build.sh cxxflags=--coverage linkflags=--coverage 
 #cxxflags=-fprofile-arcs cxxflags=-ftest-coverage linkflags=-fprofile-arcs linkflags=-ftest-coverage
 
 # switch back to the original source code directory


### PR DESCRIPTION
This makes sure it can be called e.g. from inside the libraries test folder

FTR: My current setup looks like this:

```
  - export BOOST_CI=$PWD/boost-ci
  - git clone https://github.com/boostorg/boost-ci.git $BOOST_CI
  - cp -pr $BOOST_CI/.codecov.yml .
  - source $BOOST_CI/ci/travis/install.sh
        - cd $BOOST_ROOT/libs/$SELF/test
        - $BOOST_CI/ci/travis/codecov.sh
```

This avoids some useless copies and shows some assumptions this made