### PR TITLE
Fallback to using TRAVIS_COMPILER for getting gcov version

### DIFF
--- a/ci/travis/codecov.sh
+++ b/ci/travis/codecov.sh
@@ -16,12 +16,15 @@ set -ex
 . ci/travis/enforce.sh
 
 if [ -z "$GCOV" ]; then
+    ver=7 # default
     if [ "${B2_TOOLSET%%-*}" == "gcc" ]; then
-        ver="${B2_TOOLSET#*-}"
-        GCOV=gcov-${ver}
-    else
-        GCOV=gcov-7 # default
+        if [[ "$B2_TOOLSET" =~ gcc- ]]; then
+            ver="${B2_TOOLSET##*gcc-}"
+        elif [[ "$TRAVIS_COMPILER" =~ gcc- ]]; then
+            ver="${TRAVIS_COMPILER##*gcc-}"
+        fi
     fi
+    GCOV=gcov-${ver}
 fi
 
 # lcov after 1.14 needs this


### PR DESCRIPTION
This allows using `gcc` as the toolset but having `TRAVIS_COMPILER` set to `gcc-8`

See https://github.com/boostorg/boost-ci/issues/30 for more reasoning on using this.