### PR TITLE
Make lcov_branch_coverage configurable

### DIFF
--- a/ci/travis/codecov.sh
+++ b/ci/travis/codecov.sh
@@ -45,17 +45,17 @@ ci/travis/build.sh cxxflags=--coverage linkflags=--coverage
 cd $TRAVIS_BUILD_DIR
 
 # coverage files are in ../../b2 from this location
-lcov --gcov-tool=$GCOV --rc lcov_branch_coverage=1 --base-directory "$BOOST_ROOT/libs/$SELF" --directory "$BOOST_ROOT" --capture --output-file all.info
+lcov --gcov-tool=$GCOV --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE:-1} --base-directory "$BOOST_ROOT/libs/$SELF" --directory "$BOOST_ROOT" --capture --output-file all.info
 
 # all.info contains all the coverage info for all projects - limit to ours
 # first we extract the interesting headers for our project then we use that list to extract the right things
 for f in `for f in include/boost/*; do echo $f; done | cut -f2- -d/`; do echo "*/$f*"; done > /tmp/interesting
 echo headers that matter:
 cat /tmp/interesting
-xargs -L 999999 -a /tmp/interesting lcov --gcov-tool=$GCOV --rc lcov_branch_coverage=1 --extract all.info {} "*/libs/$SELF/src/*" --output-file coverage.info
+xargs -L 999999 -a /tmp/interesting lcov --gcov-tool=$GCOV --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE:-1} --extract all.info {} "*/libs/$SELF/src/*" --output-file coverage.info
 
 # dump a summary on the console - helps us identify problems in pathing
-lcov --gcov-tool=$GCOV --rc lcov_branch_coverage=1 --list coverage.info
+lcov --gcov-tool=$GCOV --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE:-1} --list coverage.info
 
 #
 # upload to codecov.io


### PR DESCRIPTION
This disables the collection of branch coverage. Making lines fully covered with this option set to 1 is not practical, because function calls which can throw have an additional invisible branch representing the path taken when an exception takes place.

There are other more practical ways to get full coverage in the presence of exceptions (e.g. tehcniques used in Boost.Beast).

By setting lcov_branch_coverage=0 it is possible to get full coverage for a library with effort, otherwise it is difficult to impossible.

An alternative to setting it to 0 is making it a configurable option, but someone would need to write that code.