### PR TITLE
AzP macOS-10.13 and vs2015-win2012r2 images are being removed

### DIFF
--- a/templates/azure-pipelines.yml
+++ b/templates/azure-pipelines.yml
@@ -110,7 +110,7 @@ stages:
           LLVM_REPO: llvm-toolchain-xenial-5.0
         Clang 4:
           B2_TOOLSET: clang
-          B2_CXXSTD: 11,14,17
+          B2_CXXSTD: 11,14
           CXX: clang++-4.0
           PACKAGES: clang-4.0
           LLVM_REPO: llvm-toolchain-xenial-4.0
@@ -152,7 +152,7 @@ stages:
         sudo -E apt-get -yq --no-install-suggests --no-install-recommends install ${PACKAGES}
 
         git clone --branch master https://github.com/boostorg/boost-ci.git boost-ci-cloned
-        cp -pr boost-ci/ci .
+        cp -prf boost-ci-cloned/ci .
         rm -rf boost-ci-cloned
         source ci/azure-pipelines/install.sh
 
@@ -249,28 +249,24 @@ stages:
           XCODE_APP: /Applications/Xcode_11.1.app
         Xcode 10.3:
           B2_TOOLSET: clang
-          B2_CXXSTD: 14,17,2a
+          B2_CXXSTD: 11,14,17,2a
           XCODE_APP: /Applications/Xcode_10.3.app
         Xcode 10.2.1:
           B2_TOOLSET: clang
-          B2_CXXSTD: 14,17,2a
+          B2_CXXSTD: 11,14,17,2a
           XCODE_APP: /Applications/Xcode_10.2.1.app
         Xcode 10.2:
           B2_TOOLSET: clang
-          B2_CXXSTD: 14,17,2a
+          B2_CXXSTD: 11,14,17,2a
           XCODE_APP: /Applications/Xcode_10.2.app
         Xcode 10.1:
           B2_TOOLSET: clang
-          B2_CXXSTD: 14,17,2a
+          B2_CXXSTD: 11,14,17,2a
           XCODE_APP: /Applications/Xcode_10.1.app
         Xcode 10.0:
           B2_TOOLSET: clang
-          B2_CXXSTD: 14,17,2a
+          B2_CXXSTD: 11,14,17,2a
           XCODE_APP: /Applications/Xcode_10.app
-        Xcode 9.4.1:
-          B2_TOOLSET: clang
-          B2_CXXSTD: 11,14,17
-          XCODE_APP: /Applications/Xcode_9.4.1.app
     steps:
     - bash: |
         set -e

--- a/templates/azure-pipelines.yml
+++ b/templates/azure-pipelines.yml
@@ -200,11 +200,6 @@ stages:
           #B2_CXXSTD: 14 # default
           B2_ADDRESS_MODEL: address-model=64,32
           VM_IMAGE: 'vs2017-win2016'
-        VS 2015 C++14:
-          B2_TOOLSET: msvc-14.0
-          #B2_CXXSTD: 14 # default
-          B2_ADDRESS_MODEL: address-model=64,32
-          VM_IMAGE: 'vs2015-win2012r2'
 
     pool:
       vmImage: $(VM_IMAGE)
@@ -233,9 +228,37 @@ stages:
 
   - job: 'macOS'
     pool:
-      vmImage: 'macOS-10.13'
+      vmImage: 'macOS-10.14'
     strategy:
       matrix:
+        Xcode 11.3.1:
+          B2_TOOLSET: clang
+          B2_CXXSTD: 14,17,2a
+          XCODE_APP: /Applications/Xcode_11.3.1.app
+        Xcode 11.2.1:
+          B2_TOOLSET: clang
+          B2_CXXSTD: 14,17,2a
+          XCODE_APP: /Applications/Xcode_11.2.1.app
+        Xcode 11.2:
+          B2_TOOLSET: clang
+          B2_CXXSTD: 14,17,2a
+          XCODE_APP: /Applications/Xcode_11.2.app
+        Xcode 11.1:
+          B2_TOOLSET: clang
+          B2_CXXSTD: 14,17,2a
+          XCODE_APP: /Applications/Xcode_11.1.app
+        Xcode 10.3:
+          B2_TOOLSET: clang
+          B2_CXXSTD: 14,17,2a
+          XCODE_APP: /Applications/Xcode_10.3.app
+        Xcode 10.2.1:
+          B2_TOOLSET: clang
+          B2_CXXSTD: 14,17,2a
+          XCODE_APP: /Applications/Xcode_10.2.1.app
+        Xcode 10.2:
+          B2_TOOLSET: clang
+          B2_CXXSTD: 14,17,2a
+          XCODE_APP: /Applications/Xcode_10.2.app
         Xcode 10.1:
           B2_TOOLSET: clang
           B2_CXXSTD: 14,17,2a
@@ -248,38 +271,6 @@ stages:
           B2_TOOLSET: clang
           B2_CXXSTD: 11,14,17
           XCODE_APP: /Applications/Xcode_9.4.1.app
-        Xcode 9.4:
-          B2_TOOLSET: clang
-          B2_CXXSTD: 11,14,17
-          XCODE_APP: /Applications/Xcode_9.4.app
-        Xcode 9.3.1:
-          B2_TOOLSET: clang
-          B2_CXXSTD: 11,14,17
-          XCODE_APP: /Applications/Xcode_9.3.1.app
-        Xcode 9.3:
-          B2_TOOLSET: clang
-          B2_CXXSTD: 11,14
-          XCODE_APP: /Applications/Xcode_9.3.app
-        Xcode 9.2:
-          B2_TOOLSET: clang
-          B2_CXXSTD: 11,14
-          XCODE_APP: /Applications/Xcode_9.2.app
-        Xcode 9.1:
-          B2_TOOLSET: clang
-          B2_CXXSTD: 03,11
-          XCODE_APP: /Applications/Xcode_9.1.app
-        Xcode 9.0.1:
-          B2_TOOLSET: clang
-          B2_CXXSTD: 03,11
-          XCODE_APP: /Applications/Xcode_9.0.1.app
-        Xcode 9.0:
-          B2_TOOLSET: clang
-          B2_CXXSTD: 03,11
-          XCODE_APP: /Applications/Xcode_9.app
-        Xcode 8.3.3:
-          B2_TOOLSET: clang
-          B2_CXXSTD: 03,11
-          XCODE_APP: /Applications/Xcode_8.3.3.app
     steps:
     - bash: |
         set -e


### PR DESCRIPTION
Fixes #40.

Do tests get run on this repo?  Not sure if all of the XCode toolchains will still be there.  Also not sure how to obtain vs2015 on AzP anymore, so just deleted it.

> https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops#use-a-microsoft-hosted-agent
>
> On March 23, 2020, we'll be removing the following Azure Pipelines hosted images:
>
>    Windows Server 2012R2 with Visual Studio 2015 (`vs2015-win2012r2`)
>    macOS X High Sierra 10.13 (`macOS-10.13`)
>    Windows Server Core 1803 - (`win1803`)
>
> Customers are encouraged to migrate to `vs2017-win2016`, `macOS-10.14`, or a [self-hosted agent](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/v2-windows?view=azure-devops) respectively.
>
> For more information and instructions on how to update your pipelines that use those images, see [Removing older images in Azure Pipelines hosted pools](https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/).

- [X] Pre-req: #37 so that we can see if things work.
- [X] Update and validate Xcode versions for macOS-10.14 image.
- [X] Remove vs2015 image as no valid alternate will exist.
- [X] Should do recursive clones so repos with submodules do not have to constantly add that back in?  _Edit_: recursive clones not needed.