### PR TITLE
Remove .codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,0 @@
-fixes:
-  - home/travis/build/*/boost-root/boost/::include/boost/
-  - home/travis/build/*/boost-root/libs/*/src/::src/

--- a/templates/.travis.yml
+++ b/templates/.travis.yml
@@ -37,7 +37,7 @@ env:
 
 install:
   - git clone https://github.com/boostorg/boost-ci.git boost-ci
-  - cp -pr boost-ci/ci boost-ci/.codecov.yml .
+  - cp -pr boost-ci/ci .
   - source ci/travis/install.sh
 
 addons:

--- a/templates/azure-pipelines.yml
+++ b/templates/azure-pipelines.yml
@@ -152,7 +152,7 @@ stages:
         sudo -E apt-get -yq --no-install-suggests --no-install-recommends install ${PACKAGES}
 
         git clone --branch master https://github.com/boostorg/boost-ci.git boost-ci
-        cp -pr boost-ci/ci boost-ci/.codecov.yml .
+        cp -pr boost-ci/ci .
         rm -rf boost-ci
         source ci/azure-pipelines/install.sh
 
@@ -287,7 +287,7 @@ stages:
         which clang++
 
         git clone --branch master https://github.com/boostorg/boost-ci.git boost-ci
-        cp -pr boost-ci/ci boost-ci/.codecov.yml .
+        cp -pr boost-ci/ci .
         rm -rf boost-ci
         source ci/azure-pipelines/install.sh
 


### PR DESCRIPTION
When it should be used the following must be met:
  - The file needs to named "codecov.yml", no other variations
  - The file needs to be in the repo root, not only during build
Those are not met, hence the file is not used by codecov.io.

Additionally codecov is (now/always?) able to use good heuristics for
applying path prefix removal as it was intended by this .codecov.yml.
This is why it did work even though the file was not used.

Fixes #41 