### PR TITLE
Revert "Remove .codecov.yml"

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+fixes:
+  - home/travis/build/*/boost-root/boost/::include/boost/
+  - home/travis/build/*/boost-root/libs/*/src/::src/

--- a/templates/.travis.yml
+++ b/templates/.travis.yml
@@ -37,7 +37,7 @@ env:
 
 install:
   - git clone https://github.com/boostorg/boost-ci.git boost-ci
-  - cp -pr boost-ci/ci .
+  - cp -pr boost-ci/ci boost-ci/.codecov.yml .
   - source ci/travis/install.sh
 
 addons:

--- a/templates/azure-pipelines.yml
+++ b/templates/azure-pipelines.yml
@@ -152,7 +152,7 @@ stages:
         sudo -E apt-get -yq --no-install-suggests --no-install-recommends install ${PACKAGES}
 
         git clone --branch master https://github.com/boostorg/boost-ci.git boost-ci
-        cp -pr boost-ci/ci .
+        cp -pr boost-ci/ci boost-ci/.codecov.yml .
         rm -rf boost-ci
         source ci/azure-pipelines/install.sh
 
@@ -287,7 +287,7 @@ stages:
         command -v clang++
 
         git clone --branch master https://github.com/boostorg/boost-ci.git boost-ci
-        cp -pr boost-ci/ci .
+        cp -pr boost-ci/ci boost-ci/.codecov.yml .
         rm -rf boost-ci
         source ci/azure-pipelines/install.sh
 


### PR DESCRIPTION
Reverts boostorg/boost-ci#43


----
@Flamefire  Without running update across all libraries using boost-ci, this change will break their builds.