### PR TITLE
Clear .codecov.yml and remove from templates

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+# Copying this file into other projects has no effect when done on CI only
+# and is not required anyway

--- a/templates/azure-pipelines.yml
+++ b/templates/azure-pipelines.yml
@@ -152,7 +152,7 @@ stages:
         sudo -E apt-get -yq --no-install-suggests --no-install-recommends install ${PACKAGES}
 
         git clone --branch master https://github.com/boostorg/boost-ci.git boost-ci-cloned
-        cp -pr boost-ci/ci boost-ci/.codecov.yml .
+        cp -pr boost-ci/ci .
         rm -rf boost-ci-cloned
         source ci/azure-pipelines/install.sh
 
@@ -293,7 +293,7 @@ stages:
         rm -rf boost-ci-cloned
 =======
         git clone --branch master https://github.com/boostorg/boost-ci.git boost-ci
-        cp -pr boost-ci/ci boost-ci/.codecov.yml .
+        cp -pr boost-ci/ci .
         rm -rf boost-ci
 >>>>>>> master
         source ci/azure-pipelines/install.sh


### PR DESCRIPTION
When it should be used the following must be met:
  - The file needs to named "codecov.yml", no other variations
  - The file needs to be in the repo root, not only during build
Those are not met, hence the file is not used by codecov.io.

Additionally codecov is (now/always?) able to use good heuristics for
applying path prefix removal as it was intended by this .codecov.yml.
This is why it did work even though the file was not used.

------

Refines #43 after revert in #44