### PR TITLE
Prevent CXX env from leaking into b2 bootstrap.

### DIFF
--- a/ci/common_install.sh
+++ b/ci/common_install.sh
@@ -75,6 +75,6 @@ function show_bootstrap_log
 }
 
 trap show_bootstrap_log ERR
-./bootstrap.sh --with-toolset=${B2_TOOLSET%%-*}
+CXX= ./bootstrap.sh --with-toolset=${B2_TOOLSET%%-*}
 trap - ERR
 ./b2 headers


### PR DESCRIPTION
Having a CXX set will leak into the b2 bootstrap unintentionally causing it to use the "cxx" toolset for building b2 engine causing errors as it would need additional CXXFLAGS set that are empty.