### PR TITLE
AppVeyor: changed mingw tests to use "Visual Studio 2019" image

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -100,7 +100,7 @@ environment:
       B2_TOOLSET: gcc
 
     - FLAVOR: mingw32
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       ARCH: i686
       B2_ADDRESS_MODEL: 32
       B2_CXXSTD: 03,11
@@ -108,7 +108,7 @@ environment:
       B2_VARIANT: debug
 
     - FLAVOR: mingw64
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       ARCH: x86_64
       B2_ADDRESS_MODEL: 64
       B2_CXXSTD: 11,17


### PR DESCRIPTION
mingw-tests fail on AppVeyor since targeted image "Visual Studio 2017" wants to download outdated and no longer available packages.
This PR fixes the issue.
image "Visual Studio 2017": https://ci.appveyor.com/project/tobias-loew/unordered/builds/39215465
image "Visual Studio 2019": https://ci.appveyor.com/project/tobias-loew/unordered/builds/39226916

