### PR TITLE
Drone windows, fix exit code

### DIFF
--- a/ci/drone/functions.star
+++ b/ci/drone/functions.star
@@ -108,7 +108,7 @@ def windows_cxx(name, cxx="g++", cxxflags="", packages="", sources="", llvm_os="
           ".drone/boost-ci/ci/drone/windows-cxx-install.bat",
 
           "echo '==================================> INSTALL AND COMPILE'",
-          ".drone/%s.bat" % buildscript_to_run,
+          "cmd /c .drone\\\%s.bat `& exit" % buildscript_to_run,
         ]
       }
     ]


### PR DESCRIPTION
When calling a bat file from powershell, the correct exit code fails to be carried over in certain circumstances.  This is a workaround which improves the situation for those cases.

