### PR TITLE
small gha fix

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -140,6 +140,7 @@ jobs:
           cd ..
           git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
           cd boost-root
+          mkdir -p libs/$LIBRARY
           cp -r $GITHUB_WORKSPACE/* libs/$LIBRARY
           git submodule update --init tools/boostdep
           python tools/boostdep/depinst/depinst.py --git_args "--jobs 3" $LIBRARY


### PR DESCRIPTION
Update the ci.yml gha template. Consider this copy command:
```
cp -r $GITHUB_WORKSPACE/* libs/$LIBRARY
```
When developing a new boost library, the directory libs/$LIBRARY won't yet exist, so need to create it.