### PR TITLE
NodeJS codecov uploader

### DIFF
--- a/ci/travis/codecov.sh
+++ b/ci/travis/codecov.sh
@@ -63,6 +63,6 @@ lcov --gcov-tool=$GCOV --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE:-1} --li
 #
 # upload to codecov.io
 #
-curl -s https://codecov.io/bash > .codecov
-chmod +x .codecov
-./.codecov -f coverage.info -X gcov -x "$GCOV"
+curl -Os https://uploader.codecov.io/latest/linux/codecov
+chmod +x codecov
+./codecov -f coverage.info


### PR DESCRIPTION
Codecov is deprecating their bash uploader.  Switch to the New Uploader instead. 

More info: https://about.codecov.io/blog/introducing-codecovs-new-uploader/

