### PR TITLE
Check for SELF before overwriting it

### DIFF
--- a/.drone/drone.sh
+++ b/.drone/drone.sh
@@ -26,7 +26,9 @@ common_install () {
       unset -f cd
   fi
 
-  export SELF=`basename $REPO_NAME`
+  if [ -z "$SELF" ]; then
+    export SELF=`basename $REPO_NAME`
+  fi
   export BOOST_CI_TARGET_BRANCH="$TRAVIS_BRANCH"
   export BOOST_CI_SRC_FOLDER=$(pwd)
 

--- a/ci/azure-pipelines/install.sh
+++ b/ci/azure-pipelines/install.sh
@@ -43,7 +43,9 @@ fi
 # but into one named something like /home/vsts/work/1/s
 # SELF needs to be derived from the name of the repository
 # that this build is configured for.
-export SELF=`basename $BUILD_REPOSITORY_NAME`
+if [ -z "$SELF" ]; then
+    export SELF=`basename $BUILD_REPOSITORY_NAME`
+fi
 
 # CI builds set BUILD_SOURCEBRANCHNAME
 # Pull request builds set SYSTEM_PULLREQUEST_TARGETBRANCH.

--- a/ci/github/install.bat
+++ b/ci/github/install.bat
@@ -1,7 +1,9 @@
 @ECHO ON
 
-echo GITHUB_REPOSITORY: %GITHUB_REPOSITORY%
-for /f %%i in ("%GITHUB_REPOSITORY%") do set SELF=%%~nxi
+if not defined SELF(
+    echo GITHUB_REPOSITORY: %GITHUB_REPOSITORY%
+    for /f %%i in ("%GITHUB_REPOSITORY%") do set SELF=%%~nxi
+)
 echo SELF: %SELF%
 
 echo GITHUB_BASE_REF: %GITHUB_BASE_REF%

--- a/ci/github/install.sh
+++ b/ci/github/install.sh
@@ -13,7 +13,9 @@
 
 set -ex
 
-export SELF="${GITHUB_REPOSITORY#*/}"
+if [ -z "$SELF" ]; then
+    export SELF="${GITHUB_REPOSITORY#*/}"
+fi
 BOOST_CI_TARGET_BRANCH="${GITHUB_BASE_REF:-$GITHUB_REF}"
 export BOOST_CI_TARGET_BRANCH="${BOOST_CI_TARGET_BRANCH##*/}" # Extract branch name
 export BOOST_CI_SRC_FOLDER="$GITHUB_WORKSPACE"

--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -19,7 +19,9 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     unset -f cd
 fi
 
-export SELF=`basename $TRAVIS_BUILD_DIR`
+if [ -z "$SELF" ]; then
+    export SELF=`basename $TRAVIS_BUILD_DIR`
+fi
 export BOOST_CI_TARGET_BRANCH="$TRAVIS_BRANCH"
 export BOOST_CI_SRC_FOLDER="$TRAVIS_BUILD_DIR"
 


### PR DESCRIPTION
Allows to define SELF to the library name.
Closes #20

@glenfe @mloskot @jeking3 

Would that work for you? You could add an env var `SELF` set to the actual library name if you want to support forks using a different name. The default of getting the name from the repo name is a convenient way though.