### PR TITLE
Split coverage into setup and upload

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -117,7 +117,8 @@ environment:
 
 install:
   - git clone --depth 1 https://github.com/boostorg/boost-ci.git C:\boost-ci-cloned
-  - xcopy /s /e /q /i /y C:\boost-ci-cloned\ci .\ci
+  # Copy ci folder if not testing Boost.CI
+  - if "%APPVEYOR_PROJECT_NAME%" != "boost-ci" xcopy /s /e /q /i /y C:\boost-ci-cloned\ci .\ci
   - rmdir /s /q C:\boost-ci-cloned
   - ci\appveyor\install.bat
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -210,7 +210,8 @@ stages:
               set -e
 
               git clone --depth 1 --branch master https://github.com/boostorg/boost-ci.git boost-ci-cloned
-              cp -prf boost-ci-cloned/ci .
+              # Copy ci folder if not testing Boost.CI
+              [[ $(basename "$BUILD_REPOSITORY_NAME") = "boost-ci" ]] || cp -prf boost-ci-cloned/ci .
               rm -rf boost-ci-cloned
               source ci/azure-pipelines/install.sh
             displayName: 'Install'
@@ -263,7 +264,8 @@ stages:
         steps:
           - script: |
               git clone --depth 1 --branch master https://github.com/boostorg/boost-ci.git boost-ci-cloned
-              xcopy /s /e /q /i /y boost-ci-cloned\ci .\ci
+              REM Copy ci folder if not testing Boost.CI
+              if "%BUILD_REPOSITORY_NAME%" == "%BUILD_REPOSITORY_NAME:boost-ci=%" xcopy /s /e /q /i /y boost-ci-cloned\ci .\ci
               rmdir /s /q boost-ci-cloned
               ci\azure-pipelines\install.bat
             displayName: 'Install'
@@ -317,7 +319,8 @@ stages:
               set -e
 
               git clone --depth 1 --branch master https://github.com/boostorg/boost-ci.git boost-ci-cloned
-              cp -prf boost-ci-cloned/ci .
+              # Copy ci folder if not testing Boost.CI
+              [[ $(basename "$BUILD_REPOSITORY_NAME") = "boost-ci" ]] || cp -prf boost-ci-cloned/ci .
               rm -rf boost-ci-cloned
               source ci/azure-pipelines/install.sh
             displayName: Install

--- a/.drone/drone.sh
+++ b/.drone/drone.sh
@@ -18,17 +18,18 @@ export TRAVIS_BRANCH=$DRONE_BRANCH
 export TRAVIS_EVENT_TYPE=$DRONE_BUILD_EVENT
 
 common_install () {
+  if [ -z "$SELF" ]; then
+    export SELF=`basename $REPO_NAME`
+  fi
+
   git clone https://github.com/boostorg/boost-ci.git boost-ci-cloned --depth 1
-  cp -prf boost-ci-cloned/ci .
+  [ "$SELF" == "boost-ci" ] || cp -prf boost-ci-cloned/ci .
   rm -rf boost-ci-cloned
 
   if [ "$TRAVIS_OS_NAME" == "osx" ]; then
       unset -f cd
   fi
 
-  if [ -z "$SELF" ]; then
-    export SELF=`basename $REPO_NAME`
-  fi
   export BOOST_CI_TARGET_BRANCH="$TRAVIS_BRANCH"
   export BOOST_CI_SRC_FOLDER=$(pwd)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,10 @@ jobs:
           ref: master
           path: boost-ci-cloned
       - name: Get CI scripts folder
-        run: cp -r boost-ci-cloned/ci . && rm -rf boost-ci-cloned
+        run: |
+            # Copy ci folder if not testing Boost.CI
+            [[ "$GITHUB_REPOSITORY" =~ "boost-ci" ]] || cp -r boost-ci-cloned/ci .
+            rm -rf boost-ci-cloned
 
       - name: Install packages
         if: startsWith(matrix.os, 'ubuntu')
@@ -233,7 +236,8 @@ jobs:
           path: boost-ci-cloned
       - name: Get CI scripts folder
         run: |
-            xcopy /s /e /q /i /y boost-ci-cloned\ci .\ci
+            REM Copy ci folder if not testing Boost.CI
+            if "%GITHUB_REPOSITORY%" == "%GITHUB_REPOSITORY:boost-ci=%" xcopy /s /e /q /i /y boost-ci-cloned\ci .\ci
             rmdir /s /q boost-ci-cloned
 
       - name: Setup Boost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,13 +162,13 @@ jobs:
           B2_DONT_BOOTSTRAP: ${{matrix.cmake_tests}}
         run: source ci/github/install.sh
 
-      - name: Run tests
-        if: '!matrix.cmake_tests && !matrix.coverage'
-        run: ci/build.sh
-
-      - name: Run tests with coverage collection
+      - name: Setup coverage collection
         if: matrix.coverage
-        run: ci/codecov.sh "collect"
+        run: ci/github/codecov.sh "setup"
+
+      - name: Run tests
+        if: '!matrix.cmake_tests'
+        run: ci/build.sh
 
       - name: Upload coverage
         if: matrix.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,9 +131,7 @@ jobs:
         - B2_CXXSTD=03,11
         - B2_DEFINES="BOOST_NO_STRESS_TEST=1"
       addons: *gcc-8
-      script:
-        - cd $BOOST_ROOT/libs/$SELF
-        - ci/travis/codecov.sh
+      script: $BOOST_ROOT/libs/$SELF/ci/travis/codecov.sh
 
     - compiler: g++-8
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,8 @@ env:
 
 install:
   - git clone --depth 1 https://github.com/boostorg/boost-ci.git boost-ci-cloned
-  - cp -prf boost-ci-cloned/ci .
+  # Copy ci folder if not testing Boost.CI
+  - [[ $(basename "$TRAVIS_BUILD_DIR") = "boost-ci" ]] || cp -prf boost-ci-cloned/ci .
   - rm -rf boost-ci-cloned
   - source ci/travis/install.sh
 

--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -14,17 +14,16 @@
 # - BOOST_CI_SRC_FOLDER
 # - BOOST_ROOT
 # - SELF
-# Call with either "collect" or "upload" as parameter
+# Call with either "setup" or "upload" as parameter
 
 set -ex
 
 . $(dirname "${BASH_SOURCE[0]}")/enforce.sh
 
-if [[ "$1" == "collect" ]]; then
+if [[ "$1" == "setup" ]]; then
     export B2_VARIANT=debug
     export B2_CXXFLAGS="${B2_CXXFLAGS:+$B2_CXXFLAGS }-fkeep-static-functions --coverage"
     export B2_LINKFLAGS="${B2_LINKFLAGS:+$B2_LINKFLAGS }--coverage"
-    $(dirname "${BASH_SOURCE[0]}")/build.sh
 
 elif [[ "$1" == "upload" ]]; then
     if [ -z "$GCOV" ]; then
@@ -72,4 +71,7 @@ elif [[ "$1" == "upload" ]]; then
     curl -Os https://uploader.codecov.io/latest/linux/codecov
     chmod +x codecov
     ./codecov -f coverage.info
+else
+    echo "Invalid parameter for codecov.sh: '$1'." >&2
+    false
 fi

--- a/ci/github/codecov.sh
+++ b/ci/github/codecov.sh
@@ -1,0 +1,19 @@
+#! /bin/bash
+#
+# Copyright 2021 Alexander Grund
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+#      http://www.boost.org/LICENSE_1_0.txt)
+#
+# Bash script to run on Github to perform codecov.io integration
+#
+
+set -ex
+
+source $(dirname "${BASH_SOURCE[0]}")/../codecov.sh "$1"
+
+if [[ "$1" == "setup" ]]; then
+    echo "B2_VARIANT=$B2_VARIANT" >> "$GITHUB_ENV"
+    echo "B2_CXXFLAGS=$B2_CXXFLAGS" >> "$GITHUB_ENV"
+    echo "B2_LINKFLAGS=$B2_LINKFLAGS" >> "$GITHUB_ENV"
+fi

--- a/ci/travis/codecov.sh
+++ b/ci/travis/codecov.sh
@@ -1,6 +1,7 @@
 #! /bin/bash
 #
 # Copyright 2017 - 2019 James E. King III
+# Copyright 2021 Alexander Grund
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 #      http://www.boost.org/LICENSE_1_0.txt)
@@ -10,5 +11,8 @@
 
 set -ex
 
-$(dirname "${BASH_SOURCE[0]}")/../codecov.sh "collect"
-$(dirname "${BASH_SOURCE[0]}")/../codecov.sh "upload"
+CI_DIR="$(dirname "${BASH_SOURCE[0]}")/.."
+
+source "$CI_DIR"/codecov.sh "setup"
+"$CI_DIR"/build.sh
+"$CI_DIR"/codecov.sh "upload"


### PR DESCRIPTION
Build is done manually by the regular build.sh script. All we need is the setup (setting of CXXFLAGS etc.) and the upload part.
This allows to easily run multiple build runs (e.g. in different configurations)

Closes #94