### PR TITLE
Move CMake tests into separate jobs and test on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           - { compiler: gcc-11,    cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
           - { name: GCC w/ sanitizers, sanitize: yes,
               compiler: gcc-11,    cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
-          - { name: Collect coverage, coverage: yes, 
+          - { name: Collect coverage, coverage: yes,
               compiler: gcc-8,     cxxstd: '03,11',          os: ubuntu-20.04 }
 
           # Linux, clang
@@ -74,11 +74,9 @@ jobs:
           - { compiler: clang-12,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04, install: [clang-12, libc++-12-dev, libc++abi-12-dev], env: {B2_STDLIB: libc++ } }
           - { name: Clang w/ sanitizers, sanitize: yes,
               compiler: clang-12,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04, install: [clang-12, libc++-12-dev, libc++abi-12-dev], env: {B2_STDLIB: libc++ } }
-          
+
           # OSX, clang
           - { compiler: clang,     cxxstd: '03,11,14,17,2a', os: macos-10.15, sanitize: yes }
-
-          - { name: CMake tests, cmake_tests: 1, os: ubuntu-20.04 }
 
     timeout-minutes: 120
     runs-on: ${{matrix.os}}
@@ -162,7 +160,6 @@ jobs:
           B2_COMPILER: ${{matrix.compiler}}
           B2_CXXSTD: ${{matrix.cxxstd}}
           B2_SANITIZE: ${{matrix.sanitize}}
-          B2_DONT_BOOTSTRAP: ${{matrix.cmake_tests}}
         run: source ci/github/install.sh
 
       - name: Setup coverage collection
@@ -170,47 +167,12 @@ jobs:
         run: ci/github/codecov.sh "setup"
 
       - name: Run tests
-        if: '!matrix.cmake_tests'
         run: ci/build.sh
 
       - name: Upload coverage
         if: matrix.coverage
         run: ci/codecov.sh "upload"
 
-      - name: Run CMake tests
-        if: matrix.cmake_tests
-        run: |
-            cd "$BOOST_ROOT"
-            mkdir __build_cmake_test__ && cd __build_cmake_test__
-            cmake -DBUILD_TESTING=ON -DBOOST_INCLUDE_LIBRARIES=$SELF ..
-            cmake --build . --target tests
-            ctest --output-on-failure
-
-      - name: Run CMake subdir tests
-        if: matrix.cmake_tests
-        run: |
-            cmake_test_folder="$BOOST_ROOT/libs/$SELF/test/cmake_test" # New unified folder
-            [ -d "$cmake_test_folder" ] || cmake_test_folder="$BOOST_ROOT/libs/$SELF/test/cmake_subdir_test"
-            cd "$cmake_test_folder"
-            mkdir __build_cmake_subdir_test__ && cd __build_cmake_subdir_test__
-            cmake -DBOOST_CI_INSTALL_TEST=OFF ..
-            cmake --build .
-            cmake --build . --target check
-
-      - name: Run CMake install tests
-        if: matrix.cmake_tests
-        run: |
-            cd "$BOOST_ROOT"
-            mkdir __build_cmake_install_test__ && cd __build_cmake_install_test__
-            cmake -DBOOST_INCLUDE_LIBRARIES=$SELF -DCMAKE_INSTALL_PREFIX=~/.local -DBoost_VERBOSE=ON -DBoost_DEBUG=ON ..
-            cmake --build . --target install
-            cmake_test_folder="$BOOST_ROOT/libs/$SELF/test/cmake_test" # New unified folder
-            [ -d "$cmake_test_folder" ] || cmake_test_folder="$BOOST_ROOT/libs/$SELF/test/cmake_install_test"
-            cd "$cmake_test_folder"
-            mkdir __build_cmake_install_test__ && cd __build_cmake_install_test__
-            cmake -DBOOST_CI_INSTALL_TEST=ON -DCMAKE_INSTALL_PREFIX=~/.local ..
-            cmake --build .
-            cmake --build . --target check
   windows:
     defaults:
       run:
@@ -242,10 +204,78 @@ jobs:
 
       - name: Setup Boost
         run: ci\github\install.bat
-        
+
       - name: Run tests
         run: ci\build.bat
         env:
           B2_TOOLSET: ${{matrix.toolset}}
           B2_CXXSTD: ${{matrix.cxxstd}}
           B2_ADDRESS_MODEL: ${{matrix.addrmd}}
+
+  CMake:
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-20.04, build_shared: ON,  build_type: Debug, generator: 'Unix Makefiles' }
+          - { os: ubuntu-20.04, build_shared: OFF, build_type: Debug, generator: 'Unix Makefiles' }
+          - { os: windows-2019, build_shared: ON,  build_type: Debug, generator: 'Visual Studio 16 2019' }
+          - { os: windows-2019, build_shared: OFF, build_type: Debug, generator: 'Visual Studio 16 2019' }
+
+    timeout-minutes: 120
+    runs-on: ${{matrix.os}}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Fetch Boost.CI
+        uses: actions/checkout@v2
+        with:
+          repository: boostorg/boost-ci
+          ref: master
+          path: boost-ci-cloned
+      - name: Get CI scripts folder
+        run: |
+            # Copy ci folder if not testing Boost.CI
+            [[ "$GITHUB_REPOSITORY" =~ "boost-ci" ]] || cp -r boost-ci-cloned/ci .
+            rm -rf boost-ci-cloned
+      - name: Setup Boost
+        env: {B2_DONT_BOOTSTRAP: 1}
+        run: source ci/github/install.sh
+
+      - name: Run CMake tests
+        run: |
+            cd "$BOOST_ROOT"
+            mkdir __build_cmake_test__ && cd __build_cmake_test__
+            cmake -G "${{matrix.generator}}" -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBOOST_INCLUDE_LIBRARIES=$SELF -DBUILD_SHARED_LIBS=${{matrix.build_shared}} -DBUILD_TESTING=ON -DBoost_VERBOSE=ON ..
+            cmake --build . --target tests --config ${{matrix.build_type}}
+            ctest --output-on-failure --build-config ${{matrix.build_type}}
+
+      - name: Run CMake subdir tests
+        run: |
+            cmake_test_folder="$BOOST_ROOT/libs/$SELF/test/cmake_test" # New unified folder
+            [ -d "$cmake_test_folder" ] || cmake_test_folder="$BOOST_ROOT/libs/$SELF/test/cmake_subdir_test"
+            cd "$cmake_test_folder"
+            mkdir __build_cmake_subdir_test__ && cd __build_cmake_subdir_test__
+            cmake -G "${{matrix.generator}}" -DBOOST_CI_INSTALL_TEST=OFF -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBUILD_SHARED_LIBS=${{matrix.build_shared}} ..
+            cmake --build . --config ${{matrix.build_type}}
+            ctest --output-on-failure --build-config ${{matrix.build_type}}
+
+      - name: Install Library
+        run: |
+            cd "$BOOST_ROOT"
+            mkdir __build_cmake_install_test__ && cd __build_cmake_install_test__
+            cmake -G "${{matrix.generator}}" -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBOOST_INCLUDE_LIBRARIES=$SELF -DBUILD_SHARED_LIBS=${{matrix.build_shared}} -DCMAKE_INSTALL_PREFIX=~/.local -DBoost_VERBOSE=ON -DBoost_DEBUG=ON ..
+            cmake --build . --target install --config ${{matrix.build_type}}
+      - name: Run CMake install tests
+        run: |
+            cmake_test_folder="$BOOST_ROOT/libs/$SELF/test/cmake_test" # New unified folder
+            [ -d "$cmake_test_folder" ] || cmake_test_folder="$BOOST_ROOT/libs/$SELF/test/cmake_install_test"
+            cd "$cmake_test_folder"
+            mkdir __build_cmake_install_test__ && cd __build_cmake_install_test__
+            cmake -G "${{matrix.generator}}" -DBOOST_CI_INSTALL_TEST=ON -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBUILD_SHARED_LIBS=${{matrix.build_shared}} -DCMAKE_PREFIX_PATH=~/.local ..
+            cmake --build . --config ${{matrix.build_type}}
+            ctest --output-on-failure --build-config ${{matrix.build_type}}


### PR DESCRIPTION
Cleaner and allows to test if anything in the CMLs is generator/platform specific