### PR TITLE
Use CCache on GHA & AzP

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -100,6 +100,9 @@ stages:
           variables:
             B2_COMPILER: ${{ item.compiler }}
             B2_CXXSTD: ${{ item.cxxstd }}
+            ${{ if not(contains(item.os, 'macOS')) }}:
+              B2_USE_CCACHE: 1
+              B2_CCACHE_DIR: $(Pipeline.Workspace)/.ccache
             ${{ if item.xcode }}:
               XCODE_APP: /Applications/Xcode_${{ item.xcode }}.app
             ${{ if item.install }}:
@@ -117,6 +120,12 @@ stages:
                   sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
                   sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y g++ python libpython-dev git
                 displayName: 'Install required sw for containers'
+            - task: Cache@2
+              condition: eq(variables.B2_USE_CCACHE, '1')
+              inputs:
+                key: 'ccache|"${{ item.os }}-${{ item.container }}"|"${{ item.compiler }}"'
+                path: $(B2_CCACHE_DIR)
+              displayName: Get CCache
             - bash: |
                 set -ex
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
     timeout-minutes: 120
     runs-on: ${{matrix.os}}
     container: ${{matrix.container}}
+    env: {B2_USE_CCACHE: 1}
 
     steps:
       - name: Setup environment
@@ -105,6 +106,12 @@ jobs:
         if: 'matrix.coverage'
         with:
           fetch-depth: 0
+
+      - name: Cache ccache
+        uses: actions/cache@v2
+        with:
+          path: ~/.ccache
+          key: ${{matrix.os}}-${{matrix.container}}-${{matrix.compiler}}
 
       - name: Fetch Boost.CI
         uses: actions/checkout@v2

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -19,3 +19,8 @@ export UBSAN_OPTIONS=print_stacktrace=1
 cd "$BOOST_ROOT"
 
 ./b2 ${B2_TARGETS} "${B2_ARGS[@]}" "$@"
+
+if [ "$B2_USE_CCACHE" == "1" ] && command -v ccache &> /dev/null; then
+  echo "CCache summary"
+  ccache -s
+fi

--- a/ci/common_install.sh
+++ b/ci/common_install.sh
@@ -104,6 +104,11 @@ if [[ "$B2_TOOLSET" == clang* ]]; then
     fi
 fi
 
+# Setup ccache
+if [ "$B2_USE_CCACHE" == "1" ]; then
+    "$CI_DIR"/setup_ccache.sh
+fi
+
 # Set up user-config to actually use B2_COMPILER if set
 if [ -n "$B2_COMPILER" ]; then
     # Get C++ compiler
@@ -120,6 +125,9 @@ if [ -n "$B2_COMPILER" ]; then
     fi
     echo "Compiler location: $(command -v $CXX)"
     echo "Compiler version: $($CXX --version)"
+    if [ "$B2_USE_CCACHE" == "1" ]; then
+        CXX="ccache $CXX"
+    fi
     export CXX
 
     echo -n "using $B2_TOOLSET : : $CXX" > ~/user-config.jam

--- a/ci/setup_ccache.sh
+++ b/ci/setup_ccache.sh
@@ -1,0 +1,23 @@
+#! /bin/bash
+#
+# Copyright 2021 Alexander Grund
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+#      http://www.boost.org/LICENSE_1_0.txt)
+#
+# Installs and sets up ccache
+
+set -ex
+
+if ! command -v ccache &> /dev/null; then
+  if [ -f "/etc/debian_version" ]; then
+    sudo apt-get install ${NET_RETRY_COUNT:+ -o Acquire::Retries=$NET_RETRY_COUNT} -y ccache
+  elif command -v brew &> /dev/null; then
+    brew update > /dev/null
+    brew install ccache
+  fi
+fi
+ccache --set-config=cache_dir=${B2_CCACHE_DIR:-~/.ccache}
+ccache --set-config=max_size=${B2_CCACHE_SIZE:-500M}
+ccache -z
+echo "CCache config: $(ccache -p)"


### PR DESCRIPTION
Speeds up the builds especially when the source changes are small (or just doc changes) decreasing the PR turnaround time especially with the GHA shared hosted runners

Prepared with config params and a script generic enough to be put for other CI providers too

Based on #102