### PR TITLE
Undo move of boost-root

### DIFF
--- a/ci/common_install.bat
+++ b/ci/common_install.bat
@@ -21,11 +21,7 @@ git clone -b %BOOST_BRANCH% --depth 1 https://github.com/boostorg/boost.git boos
 cd boost-root || EXIT /B 1
 git submodule update -q --init tools/boostdep || EXIT /B 1
 xcopy /s /e /q /I %BOOST_CI_SRC_FOLDER% libs\%SELF% || EXIT /B 1
-REM Old configs expect boost in source folder
-cd ..
-move boost-root  %BOOST_CI_SRC_FOLDER%\
-set BOOST_ROOT=%BOOST_CI_SRC_FOLDER%\boost-root
-cd %BOOST_ROOT%
+set BOOST_ROOT=%cd%
 
 python tools/boostdep/depinst/depinst.py --include benchmark --include example --include examples --include tools %DEPINST% %SELF:\=/% || EXIT /B 1
 


### PR DESCRIPTION
Up until very recently, the following line in common_install.bat might have been "broken" but actually everything still worked ok.

```
move boost-root %BUILD_SOURCESDIRECTORY%\
```

Now it's been "fixed", to the correct variable:

```
move boost-root %BOOST_CI_SRC_FOLDER%\
```

Drone is getting an inexplicable error "Access is Denied" during that move command.   Actually, other files are created in %BOOST_CI_SRC_FOLDER% so the cause is not clear.   

A solution is to remove that line of code.  Don't move the boost-root directory. That's also generally simpler and easier.  

Which leads to the question: which "old configs" required the "move" step, and are they still in use?  @Flamefire ?

So far, I have tested this new proposed change on Azure Pipelines and Drone, and they completed successfully.   An Appveyor test is running now, I will report back if it fails.