### PR TITLE
Enhance and fix AzP

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -44,37 +44,31 @@ stages:
         strategy:
           matrix:
             GCC_10:
-              B2_TOOLSET: gcc
               B2_CXXSTD: 14,17,20
               CXX: g++-10
               PACKAGES: g++-10
               VM_IMAGE: ubuntu-20.04
             GCC_9:
-              B2_TOOLSET: gcc
               B2_CXXSTD: 14,17,2a
               CXX: g++-9
               PACKAGES: g++-9
               VM_IMAGE: ubuntu-20.04
             GCC_8:
-              B2_TOOLSET: gcc
               B2_CXXSTD: 14,17,2a
               CXX: g++-8
               PACKAGES: g++-8
               VM_IMAGE: ubuntu-20.04
             GCC_7:
-              B2_TOOLSET: gcc
               B2_CXXSTD: 11,14,17
               CXX: g++-7
               PACKAGES: g++-7
               VM_IMAGE: ubuntu-18.04
             GCC_6:
-              B2_TOOLSET: gcc
               B2_CXXSTD: 11,14
               CXX: g++-6
               PACKAGES: g++-6
               VM_IMAGE: ubuntu-18.04
             GCC_5:
-              B2_TOOLSET: gcc
               B2_CXXSTD: 11
               CXX: g++-5
               PACKAGES: g++-5
@@ -88,37 +82,31 @@ stages:
             #  VM_IMAGE: ubuntu-18.04
             #  containerImage: ubuntu:16.04
             GCC_4_8:
-              B2_TOOLSET: gcc
               B2_CXXSTD: 11
               CXX: g++-4.8
               PACKAGES: g++-4.8
               VM_IMAGE: ubuntu-18.04
             Clang_12:
-              B2_TOOLSET: clang
               B2_CXXSTD: 14,17,20
               CXX: clang++-12
               PACKAGES: clang-12
               VM_IMAGE: ubuntu-20.04
             Clang_11:
-              B2_TOOLSET: clang
               B2_CXXSTD: 14,17,20
               CXX: clang++-11
               PACKAGES: clang-11
               VM_IMAGE: ubuntu-20.04
             Clang_10:
-              B2_TOOLSET: clang
               B2_CXXSTD: 14,17,20
               CXX: clang++-10
               PACKAGES: clang-10
               VM_IMAGE: ubuntu-20.04
             Clang_9:
-              B2_TOOLSET: clang
               B2_CXXSTD: 14,17,2a
               CXX: clang++-9
               PACKAGES: clang-9
               VM_IMAGE: ubuntu-20.04
             Clang_8:
-              B2_TOOLSET: clang
               B2_CXXSTD: 14,17
               CXX: clang++-8
               PACKAGES: clang-8 libc6-dbg libc++-dev libstdc++-8-dev
@@ -126,7 +114,6 @@ stages:
               LLVM_REPO: llvm-toolchain-bionic-8
               VM_IMAGE: ubuntu-18.04
             Clang_7:
-              B2_TOOLSET: clang
               B2_CXXSTD: 14,17
               CXX: clang++-7
               PACKAGES: clang-7 libc6-dbg libc++-dev libstdc++-8-dev
@@ -134,7 +121,6 @@ stages:
               LLVM_REPO: llvm-toolchain-bionic-7
               VM_IMAGE: ubuntu-18.04
             Clang_6_libcxx:
-              B2_TOOLSET: clang
               B2_CXXSTD: 11,14,17
               B2_STDLIB: libc++
               CXX: clang++-6.0
@@ -143,7 +129,6 @@ stages:
               LLVM_REPO: llvm-toolchain-bionic-6.0
               VM_IMAGE: ubuntu-18.04
             Clang_6:
-              B2_TOOLSET: clang
               B2_CXXSTD: 14,17
               CXX: clang++-6.0
               PACKAGES: clang-6.0 libc6-dbg libc++-dev libc++abi-dev libstdc++-8-dev
@@ -151,48 +136,41 @@ stages:
               LLVM_REPO: llvm-toolchain-bionic-6.0
               VM_IMAGE: ubuntu-18.04
             Clang_5:
-              B2_TOOLSET: clang
               B2_CXXSTD: 11,14,17
               PACKAGES: clang-5.0
               CXX: clang++-5.0
               LLVM_REPO: llvm-toolchain-xenial-5.0
               VM_IMAGE: ubuntu-18.04
             Clang_4:
-              B2_TOOLSET: clang
               B2_CXXSTD: 11,14
               CXX: clang++-4.0
               PACKAGES: clang-4.0
               LLVM_REPO: llvm-toolchain-xenial-4.0
               VM_IMAGE: ubuntu-18.04
             Clang_3_9:
-              B2_TOOLSET: clang
               B2_CXXSTD: 11,14
               CXX: clang++-3.9
               PACKAGES: clang-3.9
               VM_IMAGE: ubuntu-18.04
             # Should move to containers. See note in containers section below.
             # Clang_3_8:
-            #   B2_TOOLSET: clang
             #   CXX: clang++-3.8
             #   B2_CXXSTD: 11,14
             #   PACKAGES: clang-3.8
             #   VM_IMAGE: ubuntu-18.04
             #   containerImage: ubuntu:16.04
             Clang_3_7:
-              B2_TOOLSET: clang
               B2_CXXSTD: 11
               CXX: clang++-3.7
               PACKAGES: clang-3.7
               VM_IMAGE: ubuntu-18.04
             Clang_3_6:
-              B2_TOOLSET: clang
               B2_CXXSTD: 11
               CXX: clang++-3.6
               PACKAGES: clang-3.6
               VM_IMAGE: ubuntu-18.04
               # Should move to containers. See note in containers section below.
               # Clang_3_5:
-              #   B2_TOOLSET: clang
               #   B2_CXXSTD: 11
               #   CXX: clang++-3.5
               #   PACKAGES: clang-3.5
@@ -275,39 +253,39 @@ stages:
         strategy:
           matrix:
             Xcode_11_3_1:
-              B2_TOOLSET: clang
+              CXX: clang++
               B2_CXXSTD: 14,17,2a
               XCODE_APP: /Applications/Xcode_11.3.1.app
             Xcode_11_2_1:
-              B2_TOOLSET: clang
+              CXX: clang++
               B2_CXXSTD: 14,17,2a
               XCODE_APP: /Applications/Xcode_11.2.1.app
             Xcode_11_2:
-              B2_TOOLSET: clang
+              CXX: clang++
               B2_CXXSTD: 14,17,2a
               XCODE_APP: /Applications/Xcode_11.2.app
             Xcode_11_1:
-              B2_TOOLSET: clang
+              CXX: clang++
               B2_CXXSTD: 14,17,2a
               XCODE_APP: /Applications/Xcode_11.1.app
             Xcode_10_3:
-              B2_TOOLSET: clang
+              CXX: clang++
               B2_CXXSTD: 11,14,17,2a
               XCODE_APP: /Applications/Xcode_10.3.app
             Xcode_10_2_1:
-              B2_TOOLSET: clang
+              CXX: clang++
               B2_CXXSTD: 11,14,17,2a
               XCODE_APP: /Applications/Xcode_10.2.1.app
             Xcode_10_2:
-              B2_TOOLSET: clang
+              CXX: clang++
               B2_CXXSTD: 11,14,17,2a
               XCODE_APP: /Applications/Xcode_10.2.app
             Xcode_10_1:
-              B2_TOOLSET: clang
+              CXX: clang++
               B2_CXXSTD: 11,14,17,2a
               XCODE_APP: /Applications/Xcode_10.1.app
             Xcode_10_0:
-              B2_TOOLSET: clang
+              CXX: clang++
               B2_CXXSTD: 11,14,17,2a
               XCODE_APP: /Applications/Xcode_10.app
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -159,16 +159,16 @@ stages:
             #   PACKAGES: clang-3.8
             #   VM_IMAGE: ubuntu-18.04
             #   containerImage: ubuntu:16.04
-            Clang_3_7:
-              B2_CXXSTD: 11
-              CXX: clang++-3.7
-              PACKAGES: clang-3.7
-              VM_IMAGE: ubuntu-18.04
-            Clang_3_6:
-              B2_CXXSTD: 11
-              CXX: clang++-3.6
-              PACKAGES: clang-3.6
-              VM_IMAGE: ubuntu-18.04
+            # Clang_3_7:
+            #   B2_CXXSTD: 11
+            #   CXX: clang++-3.7
+            #   PACKAGES: clang-3.7
+            #   VM_IMAGE: ubuntu-18.04
+            # Clang_3_6:
+            #   B2_CXXSTD: 11
+            #   CXX: clang++-3.6
+            #   PACKAGES: clang-3.6
+            #   VM_IMAGE: ubuntu-18.04
               # Should move to containers. See note in containers section below.
               # Clang_3_5:
               #   B2_CXXSTD: 11

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -182,7 +182,7 @@ stages:
 
         steps:
           - bash: |
-              set -e
+              set -ex
 
               git clone --depth 1 --branch master https://github.com/boostorg/boost-ci.git boost-ci-cloned
               # Copy ci folder if not testing Boost.CI
@@ -191,7 +191,7 @@ stages:
               source ci/azure-pipelines/install.sh
             displayName: 'Install'
           - bash: |
-              set -e
+              set -ex
               echo "SELF=$SELF"
               echo "BOOST_ROOT=$BOOST_ROOT"
 
@@ -291,7 +291,7 @@ stages:
 
         steps:
           - bash: |
-              set -e
+              set -ex
 
               git clone --depth 1 --branch master https://github.com/boostorg/boost-ci.git boost-ci-cloned
               # Copy ci folder if not testing Boost.CI
@@ -300,7 +300,7 @@ stages:
               source ci/azure-pipelines/install.sh
             displayName: Install
           - bash: |
-              set -e
+              set -ex
               echo "SELF=$SELF"
               echo "BOOST_ROOT=$BOOST_ROOT"
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -33,6 +33,8 @@ trigger:
 pr: [develop, master, main]
 
 variables:
+  GIT_FETCH_JOBS: 4
+  NET_RETRY_COUNT: 5
   B2_CI_VERSION: 1
   B2_VARIANT: release,debug
   B2_LINK: shared,static
@@ -46,65 +48,53 @@ stages:
             GCC_10:
               B2_CXXSTD: 14,17,20
               CXX: g++-10
-              PACKAGES: g++-10
               VM_IMAGE: ubuntu-20.04
             GCC_9:
               B2_CXXSTD: 14,17,2a
               CXX: g++-9
-              PACKAGES: g++-9
               VM_IMAGE: ubuntu-20.04
             GCC_8:
               B2_CXXSTD: 14,17,2a
               CXX: g++-8
-              PACKAGES: g++-8
               VM_IMAGE: ubuntu-20.04
             GCC_7:
               B2_CXXSTD: 11,14,17
               CXX: g++-7
-              PACKAGES: g++-7
               VM_IMAGE: ubuntu-18.04
             GCC_6:
               B2_CXXSTD: 11,14
               CXX: g++-6
-              PACKAGES: g++-6
               VM_IMAGE: ubuntu-18.04
             GCC_5:
               B2_CXXSTD: 11
               CXX: g++-5
-              PACKAGES: g++-5
               VM_IMAGE: ubuntu-18.04
             # Should move to containers. See note in containers section below.
             #  GCC_4_9:
             #  B2_TOOLSET: gcc
             #  B2_CXXSTD: 11
             #  CXX: g++-4.9
-            #  PACKAGES: g++-4.9
             #  VM_IMAGE: ubuntu-18.04
             #  containerImage: ubuntu:16.04
             GCC_4_8:
               B2_CXXSTD: 11
               CXX: g++-4.8
-              PACKAGES: g++-4.8
               VM_IMAGE: ubuntu-18.04
             Clang_12:
               B2_CXXSTD: 14,17,20
               CXX: clang++-12
-              PACKAGES: clang-12
               VM_IMAGE: ubuntu-20.04
             Clang_11:
               B2_CXXSTD: 14,17,20
               CXX: clang++-11
-              PACKAGES: clang-11
               VM_IMAGE: ubuntu-20.04
             Clang_10:
               B2_CXXSTD: 14,17,20
               CXX: clang++-10
-              PACKAGES: clang-10
               VM_IMAGE: ubuntu-20.04
             Clang_9:
               B2_CXXSTD: 14,17,2a
               CXX: clang++-9
-              PACKAGES: clang-9
               VM_IMAGE: ubuntu-20.04
             Clang_8:
               B2_CXXSTD: 14,17
@@ -137,43 +127,36 @@ stages:
               VM_IMAGE: ubuntu-18.04
             Clang_5:
               B2_CXXSTD: 11,14,17
-              PACKAGES: clang-5.0
               CXX: clang++-5.0
               LLVM_REPO: llvm-toolchain-xenial-5.0
               VM_IMAGE: ubuntu-18.04
             Clang_4:
               B2_CXXSTD: 11,14
               CXX: clang++-4.0
-              PACKAGES: clang-4.0
               LLVM_REPO: llvm-toolchain-xenial-4.0
               VM_IMAGE: ubuntu-18.04
             Clang_3_9:
               B2_CXXSTD: 11,14
               CXX: clang++-3.9
-              PACKAGES: clang-3.9
               VM_IMAGE: ubuntu-18.04
             # Should move to containers. See note in containers section below.
             # Clang_3_8:
             #   CXX: clang++-3.8
             #   B2_CXXSTD: 11,14
-            #   PACKAGES: clang-3.8
             #   VM_IMAGE: ubuntu-18.04
             #   containerImage: ubuntu:16.04
             # Clang_3_7:
             #   B2_CXXSTD: 11
             #   CXX: clang++-3.7
-            #   PACKAGES: clang-3.7
             #   VM_IMAGE: ubuntu-18.04
             # Clang_3_6:
             #   B2_CXXSTD: 11
             #   CXX: clang++-3.6
-            #   PACKAGES: clang-3.6
             #   VM_IMAGE: ubuntu-18.04
               # Should move to containers. See note in containers section below.
               # Clang_3_5:
               #   B2_CXXSTD: 11
               #   CXX: clang++-3.5
-              #   PACKAGES: clang-3.5
               #   VM_IMAGE: ubuntu-18.04
               #   containerImage: ubuntu:16.04
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -30,10 +30,7 @@ trigger:
       - fix/*
       - pr/*
 
-pr:
-  branches:
-    include:
-      - develop
+pr: [develop, master, main]
 
 variables:
   B2_CI_VERSION: 1

--- a/ci/azure-pipelines/install.sh
+++ b/ci/azure-pipelines/install.sh
@@ -44,6 +44,20 @@ fi
 export BOOST_CI_TARGET_BRANCH="${SYSTEM_PULLREQUEST_TARGETBRANCH:-$BUILD_SOURCEBRANCHNAME}"
 export BOOST_CI_SRC_FOLDER="$BUILD_SOURCESDIRECTORY"
 
+if [ -z "${B2_TOOLSET}" ]; then
+    if [[ "$CXX" =~ clang ]]; then
+      B2_TOOLSET=clang
+    elif [[ "$CXX" =~ gcc|g\+\+ ]]; then
+      B2_TOOLSET=gcc
+    else
+      echo "Unknown compiler: '$CXX'. Need either clang or gcc/g++" >&2
+      false
+    fi
+    set +x
+    echo "##vso[task.setvariable variable=B2_TOOLSET]$B2_TOOLSET"
+    set -x
+fi
+
 . $(dirname "${BASH_SOURCE[0]}")/../common_install.sh
 
 # AzP official images of Ubuntu 16.04 behave differently to Travis CI.

--- a/ci/common_install.sh
+++ b/ci/common_install.sh
@@ -61,7 +61,7 @@ if [[ "$B2_TOOLSET" == clang* ]]; then
         ver=""
         if [[ "$B2_TOOLSET" == clang-* ]]; then
             ver="${B2_TOOLSET#*-}"
-        elif [[ "$B2_COMPILER" == clang-* ]]; then
+        elif [[ "$B2_COMPILER" == clang-* ]] || [[ "$B2_COMPILER" == clang++-* ]]; then
             ver="${B2_COMPILER#*-}"
         else
             echo "Can't get clang version from B2_TOOLSET or B2_COMPILER. Skipping PATH setting." >&2

--- a/ci/github/install.sh
+++ b/ci/github/install.sh
@@ -20,37 +20,6 @@ export BOOST_CI_SRC_FOLDER="${GITHUB_WORKSPACE//\\//}"
 echo "BOOST_CI_TARGET_BRANCH=$BOOST_CI_TARGET_BRANCH" >> $GITHUB_ENV
 echo "BOOST_CI_SRC_FOLDER=$BOOST_CI_SRC_FOLDER" >> $GITHUB_ENV
 
-# B2_COMPILER is optional, e.g. unset for CMake builds -> Only checkout
-if [ -n "$B2_COMPILER" ]; then
-    echo "B2_COMPILER=$B2_COMPILER" >> $GITHUB_ENV
-    if [[ "$B2_COMPILER" == "clang" ]] || [[ "$B2_COMPILER" == clang-* ]]; then
-      B2_TOOLSET=clang
-      export CXX=${B2_COMPILER/clang/clang++}
-    elif [[ "$B2_COMPILER" =~ gcc ]]; then
-      B2_TOOLSET=gcc
-      export CXX=${B2_COMPILER/gcc/g++}
-    else
-      echo "Unknown compiler: '$B2_COMPILER'. Need either clang(-version) or gcc(-version)" >&2
-      false
-    fi
-    if [[ "$B2_COMPILER" == clang-* ]]; then
-      llvmPath="/usr/lib/llvm-${B2_COMPILER#*-}/bin"
-      echo "$llvmPath" >> $GITHUB_PATH
-    fi
-
-    echo "Compiler location: $(command -v $CXX)"
-    echo -n "using $B2_TOOLSET : : $CXX" > ~/user-config.jam
-    if [ -n "$GCC_TOOLCHAIN_ROOT" ]; then
-        echo -n " : <compileflags>\"--gcc-toolchain=$GCC_TOOLCHAIN_ROOT\" <linkflags>\"--gcc-toolchain=$GCC_TOOLCHAIN_ROOT\"" >> ~/user-config.jam
-    fi
-    echo " ;" >> ~/user-config.jam
-
-    $B2_COMPILER --version
-    $CXX --version
-
-    echo "B2_TOOLSET=$B2_TOOLSET" >> $GITHUB_ENV
-fi
-
 echo "B2_CXXSTD=$B2_CXXSTD" >> $GITHUB_ENV
 if [[ "$B2_SANITIZE" == "yes" ]]; then
   echo "B2_ASAN=1" >> $GITHUB_ENV
@@ -63,3 +32,5 @@ fi
 . $(dirname "${BASH_SOURCE[0]}")/../common_install.sh
 echo "SELF=$SELF" >> $GITHUB_ENV
 echo "BOOST_ROOT=$BOOST_ROOT" >> $GITHUB_ENV
+echo "B2_TOOLSET=$B2_TOOLSET" >> $GITHUB_ENV
+echo "B2_COMPILER=$B2_COMPILER" >> $GITHUB_ENV

--- a/ci/github/install.sh
+++ b/ci/github/install.sh
@@ -33,16 +33,17 @@ if [ -n "$B2_COMPILER" ]; then
       echo "Unknown compiler: '$B2_COMPILER'. Need either clang(-version) or gcc(-version)" >&2
       false
     fi
+    if [[ "$B2_COMPILER" == clang-* ]]; then
+      llvmPath="/usr/lib/llvm-${B2_COMPILER#*-}/bin"
+      echo "$llvmPath" >> $GITHUB_PATH
+    fi
+
+    echo "Compiler location: $(command -v $CXX)"
     echo -n "using $B2_TOOLSET : : $CXX" > ~/user-config.jam
     if [ -n "$GCC_TOOLCHAIN_ROOT" ]; then
         echo -n " : <compileflags>\"--gcc-toolchain=$GCC_TOOLCHAIN_ROOT\" <linkflags>\"--gcc-toolchain=$GCC_TOOLCHAIN_ROOT\"" >> ~/user-config.jam
     fi
     echo " ;" >> ~/user-config.jam
-
-    if [[ "$B2_COMPILER" == clang-* ]]; then
-      llvmPath="/usr/lib/llvm-${B2_COMPILER#*-}/bin"
-      echo "$llvmPath" >> $GITHUB_PATH
-    fi
 
     $B2_COMPILER --version
     $CXX --version


### PR DESCRIPTION
A few enhancements for AzP:
- Build PRs against master (or as some prefer: main), especially important for testing Boost.CI
- Deduce B2_TOOLSET from CXX/B2_COMPILER as on GHA
- Verbose (`set -x`) output of the scripts in the yml
- Catch the case where the compiler is missing and error out instead of falling back to system compiler. Closes #99 although maintainers need to remove affected jobs which will now fail. Will provide a container-based solution soon.
- Finally a bigger commit to share more stuff from GHA and Azure (i.e. Linux jobs) in the common_install.yml as well as using `GIT_FETCH_JOBS` and `NET_RETRY_COUNT` also on Azure for faster/more reliable CI

Note: I know the diff is large. Better viewed side-by-side. There is not to much going on here but mostly moving things around