### PR TITLE
Add container support to Azure

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -119,7 +119,9 @@ stages:
             - bash: |
                 set -ex
 
-                git clone --depth 1 --branch master https://github.com/boostorg/boost-ci.git boost-ci-cloned
+                for i in {1..$NET_RETRY_COUNT}; do
+                  git clone --depth 1 --branch master https://github.com/boostorg/boost-ci.git boost-ci-cloned && break || sleep 2
+                done
                 # Copy ci folder if not testing Boost.CI
                 [[ $(basename "$BUILD_REPOSITORY_NAME") = "boost-ci" ]] || cp -prf boost-ci-cloned/ci .
                 rm -rf boost-ci-cloned

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -41,7 +41,7 @@ variables:
 
 # Dummy runtime parameter to allow creating conditional jobs
 parameters:
-  - name: linux_jobs
+  - name: jobs
     type: object
     default:
       - { compiler: gcc-10,    cxxstd: '14,17,20', os: ubuntu-20.04 }
@@ -59,7 +59,7 @@ parameters:
       - { compiler: clang-8,   cxxstd: '14,17',    os: ubuntu-18.04, install: 'clang-8 libc6-dbg libc++-dev libstdc++-8-dev' }
       - { compiler: clang-7,   cxxstd: '14,17',    os: ubuntu-18.04, install: 'clang-7 libc6-dbg libc++-dev libstdc++-8-dev' }
       - { compiler: clang-6.0, cxxstd: '11,14,17', os: ubuntu-18.04, install: 'clang-6.0 libc6-dbg libc++-dev libc++abi-dev libstdc++-8-dev', env: {B2_STDLIB: libc++ } }
-      - { name: clang_6_libcxx,
+      - { name: Linux_clang_6_libcxx,
           compiler: clang-6.0, cxxstd: '11,14,17', os: ubuntu-18.04, install: 'clang-6.0 libc6-dbg libc++-dev libc++abi-dev libstdc++-8-dev' }
       - { compiler: clang-5.0, cxxstd: '11,14,17', os: ubuntu-18.04 }
       - { compiler: clang-4.0, cxxstd: '11,14',    os: ubuntu-18.04 }
@@ -68,14 +68,26 @@ parameters:
       - { compiler: clang-3.7, cxxstd: '11',       os: ubuntu-18.04, container: 'ubuntu:16.04' }
       - { compiler: clang-3.6, cxxstd: '11',       os: ubuntu-18.04, container: 'ubuntu:16.04' }
       - { compiler: clang-3.5, cxxstd: '11',       os: ubuntu-18.04, container: 'ubuntu:16.04' }
+      # OSX
+      - { compiler: clang, cxxstd: '14,17,2a',    os: macOS-10.14, xcode: 11.3.1 }
+      - { compiler: clang, cxxstd: '14,17,2a',    os: macOS-10.14, xcode: 11.2.1 }
+      - { compiler: clang, cxxstd: '14,17,2a',    os: macOS-10.14, xcode: 11.3 }
+      - { compiler: clang, cxxstd: '14,17,2a',    os: macOS-10.14, xcode: 11.1 }
+      - { compiler: clang, cxxstd: '11,14,17,2a', os: macOS-10.14, xcode: 10.3 }
+      - { compiler: clang, cxxstd: '11,14,17,2a', os: macOS-10.14, xcode: 10.2.1 }
+      - { compiler: clang, cxxstd: '11,14,17,2a', os: macOS-10.14, xcode: 10.2 }
+      - { compiler: clang, cxxstd: '11,14,17,2a', os: macOS-10.14, xcode: 10.1 }
+      - { compiler: clang, cxxstd: '11,14,17,2a', os: macOS-10.14, xcode: 10.0 }
 
 stages:
   - stage: Test
     jobs:
       # Dynamically generate jobs to be able to insert containers, see https://stackoverflow.com/questions/70046143
-      - ${{ each item in parameters.linux_jobs }}:
+      - ${{ each item in parameters.jobs }}:
         - ${{ if item.name }}:
-            job: Linux_${{ item.name }}
+            job: ${{ item.name }}
+          ${{ elseif contains(item.os, 'macOS') }}:
+            job: macOS_${{ replace(item.xcode, '.', '_') }}
           ${{ else }}:
             job: Linux_${{ replace(replace(item.compiler, '-', '_'), '.', '_') }}
           pool:
@@ -88,6 +100,8 @@ stages:
           variables:
             B2_COMPILER: ${{ item.compiler }}
             B2_CXXSTD: ${{ item.cxxstd }}
+            ${{ if item.xcode }}:
+              XCODE_APP: /Applications/Xcode_${{ item.xcode }}.app
             ${{ if item.install }}:
               PACKAGES: ${{ item.install }}
             ${{ each var in item.env }}:
@@ -157,65 +171,4 @@ stages:
               ci\azure-pipelines\install.bat
             displayName: 'Install'
           - script: ci\build.bat
-            displayName: 'Build'
-
-      - job: 'macOS'
-        pool:
-          vmImage: 'macOS-10.14'
-        strategy:
-          matrix:
-            Xcode_11_3_1:
-              CXX: clang++
-              B2_CXXSTD: 14,17,2a
-              XCODE_APP: /Applications/Xcode_11.3.1.app
-            Xcode_11_2_1:
-              CXX: clang++
-              B2_CXXSTD: 14,17,2a
-              XCODE_APP: /Applications/Xcode_11.2.1.app
-            Xcode_11_2:
-              CXX: clang++
-              B2_CXXSTD: 14,17,2a
-              XCODE_APP: /Applications/Xcode_11.2.app
-            Xcode_11_1:
-              CXX: clang++
-              B2_CXXSTD: 14,17,2a
-              XCODE_APP: /Applications/Xcode_11.1.app
-            Xcode_10_3:
-              CXX: clang++
-              B2_CXXSTD: 11,14,17,2a
-              XCODE_APP: /Applications/Xcode_10.3.app
-            Xcode_10_2_1:
-              CXX: clang++
-              B2_CXXSTD: 11,14,17,2a
-              XCODE_APP: /Applications/Xcode_10.2.1.app
-            Xcode_10_2:
-              CXX: clang++
-              B2_CXXSTD: 11,14,17,2a
-              XCODE_APP: /Applications/Xcode_10.2.app
-            Xcode_10_1:
-              CXX: clang++
-              B2_CXXSTD: 11,14,17,2a
-              XCODE_APP: /Applications/Xcode_10.1.app
-            Xcode_10_0:
-              CXX: clang++
-              B2_CXXSTD: 11,14,17,2a
-              XCODE_APP: /Applications/Xcode_10.app
-
-        steps:
-          - bash: |
-              set -ex
-
-              git clone --depth 1 --branch master https://github.com/boostorg/boost-ci.git boost-ci-cloned
-              # Copy ci folder if not testing Boost.CI
-              [[ $(basename "$BUILD_REPOSITORY_NAME") = "boost-ci" ]] || cp -prf boost-ci-cloned/ci .
-              rm -rf boost-ci-cloned
-              source ci/azure-pipelines/install.sh
-            displayName: Install
-          - bash: |
-              set -ex
-              echo "SELF=$SELF"
-              echo "BOOST_ROOT=$BOOST_ROOT"
-
-              cd $BOOST_ROOT/libs/$SELF
-              ci/azure-pipelines/build.sh
             displayName: 'Build'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,7 +1,7 @@
 ---
 # Copyright 2015-2019 Rene Rivera.
 # Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
-# Copyright 2020 Alexander Grund
+# Copyright 2020-2021 Alexander Grund
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
 
@@ -39,157 +39,86 @@ variables:
   B2_VARIANT: release,debug
   B2_LINK: shared,static
 
+# Dummy runtime parameter to allow creating conditional jobs
+parameters:
+  - name: linux_jobs
+    type: object
+    default:
+      - { compiler: gcc-10,    cxxstd: '14,17,20', os: ubuntu-20.04 }
+      - { compiler: gcc-9,     cxxstd: '14,17,2a', os: ubuntu-20.04 }
+      - { compiler: gcc-8,     cxxstd: '14,17,2a', os: ubuntu-20.04 }
+      - { compiler: gcc-7,     cxxstd: '11,14,17', os: ubuntu-18.04 }
+      - { compiler: gcc-6,     cxxstd: '11,14',    os: ubuntu-18.04 }
+      - { compiler: gcc-5,     cxxstd: '11',       os: ubuntu-18.04 }
+      - { compiler: gcc-4.9,   cxxstd: '11',       os: ubuntu-18.04, container: 'ubuntu:16.04' }
+      - { compiler: gcc-4.8,   cxxstd: '11',       os: ubuntu-18.04 }
+      - { compiler: clang-12,  cxxstd: '14,17,20', os: ubuntu-20.04 }
+      - { compiler: clang-11,  cxxstd: '14,17,20', os: ubuntu-20.04 }
+      - { compiler: clang-10,  cxxstd: '14,17,20', os: ubuntu-20.04 }
+      - { compiler: clang-9,   cxxstd: '14,17,2a', os: ubuntu-20.04 }
+      - { compiler: clang-8,   cxxstd: '14,17',    os: ubuntu-18.04, install: 'clang-8 libc6-dbg libc++-dev libstdc++-8-dev' }
+      - { compiler: clang-7,   cxxstd: '14,17',    os: ubuntu-18.04, install: 'clang-7 libc6-dbg libc++-dev libstdc++-8-dev' }
+      - { compiler: clang-6.0, cxxstd: '11,14,17', os: ubuntu-18.04, install: 'clang-6.0 libc6-dbg libc++-dev libc++abi-dev libstdc++-8-dev', env: {B2_STDLIB: libc++ } }
+      - { name: clang_6_libcxx,
+          compiler: clang-6.0, cxxstd: '11,14,17', os: ubuntu-18.04, install: 'clang-6.0 libc6-dbg libc++-dev libc++abi-dev libstdc++-8-dev' }
+      - { compiler: clang-5.0, cxxstd: '11,14,17', os: ubuntu-18.04 }
+      - { compiler: clang-4.0, cxxstd: '11,14',    os: ubuntu-18.04 }
+      - { compiler: clang-3.9, cxxstd: '11,14',    os: ubuntu-18.04 }
+      - { compiler: clang-3.8, cxxstd: '11,14',    os: ubuntu-18.04, container: 'ubuntu:16.04' }
+      - { compiler: clang-3.7, cxxstd: '11',       os: ubuntu-18.04, container: 'ubuntu:16.04' }
+      - { compiler: clang-3.6, cxxstd: '11',       os: ubuntu-18.04, container: 'ubuntu:16.04' }
+      - { compiler: clang-3.5, cxxstd: '11',       os: ubuntu-18.04, container: 'ubuntu:16.04' }
+
 stages:
   - stage: Test
     jobs:
-      - job: 'Linux'
-        strategy:
-          matrix:
-            GCC_10:
-              B2_CXXSTD: 14,17,20
-              CXX: g++-10
-              VM_IMAGE: ubuntu-20.04
-            GCC_9:
-              B2_CXXSTD: 14,17,2a
-              CXX: g++-9
-              VM_IMAGE: ubuntu-20.04
-            GCC_8:
-              B2_CXXSTD: 14,17,2a
-              CXX: g++-8
-              VM_IMAGE: ubuntu-20.04
-            GCC_7:
-              B2_CXXSTD: 11,14,17
-              CXX: g++-7
-              VM_IMAGE: ubuntu-18.04
-            GCC_6:
-              B2_CXXSTD: 11,14
-              CXX: g++-6
-              VM_IMAGE: ubuntu-18.04
-            GCC_5:
-              B2_CXXSTD: 11
-              CXX: g++-5
-              VM_IMAGE: ubuntu-18.04
-            # Should move to containers. See note in containers section below.
-            #  GCC_4_9:
-            #  B2_TOOLSET: gcc
-            #  B2_CXXSTD: 11
-            #  CXX: g++-4.9
-            #  VM_IMAGE: ubuntu-18.04
-            #  containerImage: ubuntu:16.04
-            GCC_4_8:
-              B2_CXXSTD: 11
-              CXX: g++-4.8
-              VM_IMAGE: ubuntu-18.04
-            Clang_12:
-              B2_CXXSTD: 14,17,20
-              CXX: clang++-12
-              VM_IMAGE: ubuntu-20.04
-            Clang_11:
-              B2_CXXSTD: 14,17,20
-              CXX: clang++-11
-              VM_IMAGE: ubuntu-20.04
-            Clang_10:
-              B2_CXXSTD: 14,17,20
-              CXX: clang++-10
-              VM_IMAGE: ubuntu-20.04
-            Clang_9:
-              B2_CXXSTD: 14,17,2a
-              CXX: clang++-9
-              VM_IMAGE: ubuntu-20.04
-            Clang_8:
-              B2_CXXSTD: 14,17
-              CXX: clang++-8
-              PACKAGES: clang-8 libc6-dbg libc++-dev libstdc++-8-dev
-              LLVM_OS: bionic
-              LLVM_REPO: llvm-toolchain-bionic-8
-              VM_IMAGE: ubuntu-18.04
-            Clang_7:
-              B2_CXXSTD: 14,17
-              CXX: clang++-7
-              PACKAGES: clang-7 libc6-dbg libc++-dev libstdc++-8-dev
-              LLVM_OS: bionic
-              LLVM_REPO: llvm-toolchain-bionic-7
-              VM_IMAGE: ubuntu-18.04
-            Clang_6_libcxx:
-              B2_CXXSTD: 11,14,17
-              B2_STDLIB: libc++
-              CXX: clang++-6.0
-              PACKAGES: clang-6.0 libc6-dbg libc++-dev libc++abi-dev libstdc++-8-dev
-              LLVM_OS: bionic
-              LLVM_REPO: llvm-toolchain-bionic-6.0
-              VM_IMAGE: ubuntu-18.04
-            Clang_6:
-              B2_CXXSTD: 14,17
-              CXX: clang++-6.0
-              PACKAGES: clang-6.0 libc6-dbg libc++-dev libc++abi-dev libstdc++-8-dev
-              LLVM_OS: bionic
-              LLVM_REPO: llvm-toolchain-bionic-6.0
-              VM_IMAGE: ubuntu-18.04
-            Clang_5:
-              B2_CXXSTD: 11,14,17
-              CXX: clang++-5.0
-              LLVM_REPO: llvm-toolchain-xenial-5.0
-              VM_IMAGE: ubuntu-18.04
-            Clang_4:
-              B2_CXXSTD: 11,14
-              CXX: clang++-4.0
-              LLVM_REPO: llvm-toolchain-xenial-4.0
-              VM_IMAGE: ubuntu-18.04
-            Clang_3_9:
-              B2_CXXSTD: 11,14
-              CXX: clang++-3.9
-              VM_IMAGE: ubuntu-18.04
-            # Should move to containers. See note in containers section below.
-            # Clang_3_8:
-            #   CXX: clang++-3.8
-            #   B2_CXXSTD: 11,14
-            #   VM_IMAGE: ubuntu-18.04
-            #   containerImage: ubuntu:16.04
-            # Clang_3_7:
-            #   B2_CXXSTD: 11
-            #   CXX: clang++-3.7
-            #   VM_IMAGE: ubuntu-18.04
-            # Clang_3_6:
-            #   B2_CXXSTD: 11
-            #   CXX: clang++-3.6
-            #   VM_IMAGE: ubuntu-18.04
-              # Should move to containers. See note in containers section below.
-              # Clang_3_5:
-              #   B2_CXXSTD: 11
-              #   CXX: clang++-3.5
-              #   VM_IMAGE: ubuntu-18.04
-              #   containerImage: ubuntu:16.04
+      # Dynamically generate jobs to be able to insert containers, see https://stackoverflow.com/questions/70046143
+      - ${{ each item in parameters.linux_jobs }}:
+        - ${{ if item.name }}:
+            job: Linux_${{ item.name }}
+          ${{ else }}:
+            job: Linux_${{ replace(replace(item.compiler, '-', '_'), '.', '_') }}
+          pool:
+            vmImage: ${{ item.os }}
+          ${{ if item.container }}:
+            container:
+              image: ${{ item.container }}
+              # Workaround for missing sudo: https://github.com/microsoft/azure-pipelines-agent/issues/2043
+              options: --name ci-container -v /usr/bin/docker:/tmp/docker:ro
+          variables:
+            B2_COMPILER: ${{ item.compiler }}
+            B2_CXXSTD: ${{ item.cxxstd }}
+            ${{ if item.install }}:
+              PACKAGES: ${{ item.install }}
+            ${{ each var in item.env }}:
+              ${{var.Key}}: ${{var.Value}}
+          steps:
+            - ${{ if item.container }}:
+              - bash: |
+                  set -ex
+                  /tmp/docker exec -t -u 0 ci-container \
+                    sh -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::='--force-confold' -y install sudo software-properties-common g++ python"
+                  # Need (newer) git
+                  sudo add-apt-repository ppa:git-core/ppa
+                  sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT update && sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y git
+                displayName: 'Install required sw for containers'
+            - bash: |
+                set -ex
 
-        pool:
-          vmImage: $(VM_IMAGE)
+                git clone --depth 1 --branch master https://github.com/boostorg/boost-ci.git boost-ci-cloned
+                # Copy ci folder if not testing Boost.CI
+                [[ $(basename "$BUILD_REPOSITORY_NAME") = "boost-ci" ]] || cp -prf boost-ci-cloned/ci .
+                rm -rf boost-ci-cloned
+                source ci/azure-pipelines/install.sh
+              displayName: 'Install'
+            - bash: |
+                set -ex
+                echo "SELF=$SELF"
+                echo "BOOST_ROOT=$BOOST_ROOT"
 
-        steps:
-          - bash: |
-              set -ex
-
-              git clone --depth 1 --branch master https://github.com/boostorg/boost-ci.git boost-ci-cloned
-              # Copy ci folder if not testing Boost.CI
-              [[ $(basename "$BUILD_REPOSITORY_NAME") = "boost-ci" ]] || cp -prf boost-ci-cloned/ci .
-              rm -rf boost-ci-cloned
-              source ci/azure-pipelines/install.sh
-            displayName: 'Install'
-          - bash: |
-              set -ex
-              echo "SELF=$SELF"
-              echo "BOOST_ROOT=$BOOST_ROOT"
-
-              cd $BOOST_ROOT/libs/$SELF
-              ci/azure-pipelines/build.sh
-            displayName: 'Build'
-
-      #
-      # 2021-09 DOCKER CONTAINERS NOTE
-      #
-      # Azure Pipeline containers don't run as root, and don't have sudo installed.
-      # https://github.com/microsoft/azure-pipelines-agent/issues/2043
-      # Luckily, this only affects a small number of jobs, which can be run in other CI.
-      # After the bug is fixed, containers may be used, similar to github/workflows/ci.yml
-      #
+                cd $BOOST_ROOT/libs/$SELF
+                ci/azure-pipelines/build.sh
+              displayName: 'Build'
 
       - job: 'Windows'
         strategy:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -111,10 +111,11 @@ stages:
               - bash: |
                   set -ex
                   /tmp/docker exec -t -u 0 ci-container \
-                    sh -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::='--force-confold' -y install sudo software-properties-common g++ python"
+                    sh -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::='--force-confold' -y install sudo software-properties-common"
                   # Need (newer) git
                   sudo add-apt-repository ppa:git-core/ppa
-                  sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT update && sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y git
+                  sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
+                  sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y g++ python libpython-dev git
                 displayName: 'Install required sw for containers'
             - bash: |
                 set -ex

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,10 +91,11 @@ jobs:
             fi
             if [ -n "${{matrix.container}}" ] && [ -f "/etc/debian_version" ]; then
                 apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
-                apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y sudo software-properties-common build-essential g++ python libpython-dev
-                # Need newer git
+                apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y sudo software-properties-common
+                # Need (newer) git
                 add-apt-repository ppa:git-core/ppa
-                apt-get -o Acquire::Retries=$NET_RETRY_COUNT update && apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y git
+                apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
+                apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y g++ python libpython-dev git
             fi
             git config --global pack.threads 0
 

--- a/ci/azure-pipelines/install.sh
+++ b/ci/azure-pipelines/install.sh
@@ -40,17 +40,16 @@ if [ -z "$B2_COMPILER" ]; then
 fi
 
 if [ "$AGENT_OS" != "Darwin" ]; then
-    # If no package set install at least the compiler
-    if [[ -z "$PACKAGES" ]]; then
+    # If no package set install at least the compiler if not already found
+    if [[ -z "$PACKAGES" ]] && ! command -v $B2_COMPILER; then
         PACKAGES="$(get_compiler_package "$B2_COMPILER")"
     fi
 
-    LLVM_OS=${LLVM_OS:-xenial}
     if [ -n "$PACKAGES" ]; then
         sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
         if [ -n "${LLVM_REPO}" ]; then
             wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-            sudo -E apt-add-repository "deb http://apt.llvm.org/${LLVM_OS}/ ${LLVM_REPO} main"
+            sudo -E apt-add-repository "deb http://apt.llvm.org/${LLVM_OS:-xenial}/ ${LLVM_REPO} main"
         fi
         sudo apt-get ${NET_RETRY_COUNT:+ -o Acquire::Retries=$NET_RETRY_COUNT} update
         sudo apt-get ${NET_RETRY_COUNT:+ -o Acquire::Retries=$NET_RETRY_COUNT} install -y ${PACKAGES}

--- a/ci/azure-pipelines/install.sh
+++ b/ci/azure-pipelines/install.sh
@@ -55,9 +55,6 @@ if [ "$AGENT_OS" != "Darwin" ]; then
         sudo apt-get ${NET_RETRY_COUNT:+ -o Acquire::Retries=$NET_RETRY_COUNT} update
         sudo apt-get ${NET_RETRY_COUNT:+ -o Acquire::Retries=$NET_RETRY_COUNT} install -y ${PACKAGES}
     fi
-elif [ -n "${XCODE_APP}" ]; then
-    sudo xcode-select -switch ${XCODE_APP}
-    which clang++
 fi
 
 . $(dirname "${BASH_SOURCE[0]}")/../common_install.sh

--- a/ci/common_install.sh
+++ b/ci/common_install.sh
@@ -85,6 +85,8 @@ if [[ "$B2_TOOLSET" == clang* ]]; then
             ls -ls /usr/lib/llvm-${ver}/bin || true
             hash -r || true
         fi
+    elif [ -n "${XCODE_APP}" ]; then
+        sudo xcode-select -switch ${XCODE_APP}
     fi
     command -v clang || true
     command -v clang++ || true

--- a/ci/common_install.sh
+++ b/ci/common_install.sh
@@ -76,7 +76,10 @@ if [[ "$B2_TOOLSET" == clang* ]]; then
         if [[ "$B2_TOOLSET" == clang-* ]]; then
             ver="${B2_TOOLSET#*-}"
         elif [[ "$B2_COMPILER" == clang-* ]] || [[ "$B2_COMPILER" == clang++-* ]]; then
-            ver="${B2_COMPILER#*-}"
+            # Don't change path if we do find the versioned compiler
+            if ! command -v $B2_COMPILER; then
+                ver="${B2_COMPILER#*-}"
+            fi
         else
             echo "Can't get clang version from B2_TOOLSET or B2_COMPILER. Skipping PATH setting." >&2
         fi
@@ -94,8 +97,8 @@ if [[ "$B2_TOOLSET" == clang* ]]; then
     # Additionally, if B2_TOOLSET is clang variant but CXX is set to g++
     # (it is on Linux images) then boost build silently ignores B2_TOOLSET and
     # uses CXX instead
-    if [[ "${CXX}" != clang* ]]; then
-        echo "CXX is set to ${CXX} in this environment which would override"
+    if [[ -n "$CXX" ]] && [[ "$CXX" != clang* ]]; then
+        echo "CXX is set to $CXX in this environment which would override"
         echo "the setting of B2_TOOLSET=clang, therefore we clear CXX here."
         export CXX=
     fi


### PR DESCRIPTION
Allows testing of older compilers (like clang 3.7) on AzP by using an Ubuntu 16.04 container.
This requires some changes to how the jobs are generated, as an empty value for `container` is an error on AzP

To further simplify the yml I used a format for job specification which mirrors what we use on GHA and doesn't require extra jobs and redundant steps for OSX

Also a bit of an effort to make the CI time lower by avoiding redundant work, i.e. `apt-get update` before trying to install an already installed compiler.