### PR TITLE
Simplify MinGW setup on appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 # Copyright 2016, 2017 Peter Dimov
 # Copyright 2017 - 2019 James E. King III
-# Copyright 2020 Alexander Grund
+# Copyright 2019 - 2021 Alexander Grund
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
 
@@ -34,6 +34,7 @@ branches:
     - /pr\/.*/
 
 matrix:
+  fast_finish: false
   # Adding MAYFAIL to any matrix job allows it to fail but the build stays green:
   allow_failures:
     - MAYFAIL: true
@@ -89,7 +90,6 @@ environment:
       ADDPATH: C:\cygwin\bin;
       B2_ADDRESS_MODEL: 32
       B2_CXXSTD: 03,11,14,1z
-      B2_THREADING: threadapi=pthread
       B2_TOOLSET: gcc
 
     - FLAVOR: cygwin (64-bit)
@@ -97,24 +97,21 @@ environment:
       ADDPATH: C:\cygwin64\bin;
       B2_ADDRESS_MODEL: 64
       B2_CXXSTD: 03,11,14,1z
-      B2_THREADING: threadapi=pthread
       B2_TOOLSET: gcc
 
     - FLAVOR: mingw32
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      ARCH: i686
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       B2_ADDRESS_MODEL: 32
-      B2_CXXSTD: 03,11
-      SCRIPT: ci\appveyor\mingw.bat
-      B2_VARIANT: debug
+      ADDPATH: C:\mingw\bin;
+      B2_CXXSTD: 03,11,14,1z
+      B2_TOOLSET: gcc
 
     - FLAVOR: mingw64
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      ARCH: x86_64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      ADDPATH: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;
       B2_ADDRESS_MODEL: 64
-      B2_CXXSTD: 11,17
-      B2_DEFINES: __USE_ISOC99
-      SCRIPT: ci\appveyor\mingw.bat
+      B2_CXXSTD: 03,11,14,1z
+      B2_TOOLSET: gcc
 
 install:
   - git clone --depth 1 https://github.com/boostorg/boost-ci.git C:\boost-ci-cloned


### PR DESCRIPTION
The "Visual Studio 2015" image has MinGW preinstalled, so just use that instead of installing it with every build.
Also test with more C++ standards.