### PR TITLE
Restrict codecov directories

### DIFF
--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -60,7 +60,7 @@ elif [[ "$1" == "upload" ]]; then
     for f in `for f in include/boost/*; do echo $f; done | cut -f2- -d/`; do echo "*/$f*"; done > /tmp/interesting
     echo headers that matter:
     cat /tmp/interesting
-    xargs -L 999999 -a /tmp/interesting lcov --gcov-tool=$GCOV --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE:-1} --extract all.info {} "*/libs/$SELF/*" --output-file coverage.info
+    xargs -L 999999 -a /tmp/interesting lcov --gcov-tool=$GCOV --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE:-1} --extract all.info {} "*/libs/$SELF/src/*" --output-file coverage.info
 
     # dump a summary on the console - helps us identify problems in pathing
     lcov --list coverage.info


### PR DESCRIPTION
Hi,

This could be both an Issue and a Pull Request.

The problem is "extra" and "test" folders are included in codecov coverage when they should not be:  
https://codecov.io/gh/vinniefalco/url/tree/1d351e8eca8ef25d0178859328ad26055abca2d1

Recently, that wasn't happening:
https://codecov.io/gh/vinniefalco/url/tree/36403a0206cb4b71607172e257ec1506f89b9807

A fix was originally added by @jeking3 in Oct 2018

```
# git show 981b0087
commit 981b0087efe7e09743deaf23dce87bcb62cf0417
Author: James E. King III <jking@apache.org>
Date:   Sun Oct 28 01:25:03 2018 +0000

    fix for lcov didn't do what was expected

diff --git a/ci/travis/codecov.sh b/ci/travis/codecov.sh
index 5d56700..42e7371 100755
--- a/ci/travis/codecov.sh
+++ b/ci/travis/codecov.sh
@@ -34,7 +34,7 @@ lcov --gcov-tool=gcov-7 --rc lcov_branch_coverage=1 --base-directory "$BOOST_ROO
 for f in `for f in include/boost/*; do echo $f; done | cut -f2- -d/`; do echo "*/$f*"; done > /tmp/interesting
 echo headers that matter:
 cat /tmp/interesting
-xargs -L 999999 -a /tmp/interesting lcov --gcov-tool=gcov-7 --rc lcov_branch_coverage=1 --extract all.info {} "*/libs/$SELF/**" --output-file coverage.info
+xargs -L 999999 -a /tmp/interesting lcov --gcov-tool=gcov-7 --rc lcov_branch_coverage=1 --extract all.info {} "*/libs/$SELF/src/*" --output-file coverage.info

 # dump a summary on the console - helps us identify problems in pathing
 lcov --gcov-tool=gcov-7 --rc lcov_branch_coverage=1 --list coverage.info
```

And reverted this month by @Flamefire 
 
Why was src/ added to the lcov command path before?  
How did it fix things?   
Are there other alternatives?

Many boostorg repositories don't even have a src/ directory, and yet this change is still effective. 