### PR TITLE
B2_CXXFLAGS processing

### DIFF
--- a/ci/enforce.sh
+++ b/ci/enforce.sh
@@ -60,11 +60,6 @@ if [ -z "$B2_CI_VERSION" ]; then
     B2_ADDRESS_MODEL="${B2_ADDRESS_MODEL#address-model=}"
     B2_LINK="${B2_LINK#link=}"
     B2_VARIANT="${B2_VARIANT#variant=}"
-    if [ -n "$B2_CXXFLAGS" ]; then
-        # Sometimes (ab)used for sanitizers, so play safe and add it to B2_FLAGS
-        B2_FLAGS="$B2_FLAGS $B2_CXXFLAGS"
-        unset B2_CXXFLAGS
-    fi
 fi
 
 # Build cmdline arguments for B2 as an array to preserve quotes


### PR DESCRIPTION
Here is another pull request which is really an "issue" so you might have an alternative solution.

Problem description:

Consider a repository such as boostorg/optional (or others) that have Drone files based on earlier Travis files where B2_CI_VERSION wasn't set to 1.  They are implicitly B2_CI_VERSION=0.

The code section in enforce.sh is triggered:
```
# For old versions strip prefix from variables
if [ -z "$B2_CI_VERSION" ]; then
```

which contains the section
```
    if [ -n "$B2_CXXFLAGS" ]; then
        # Sometimes (ab)used for sanitizers, so play safe and add it to B2_FLAGS
        B2_FLAGS="$B2_FLAGS $B2_CXXFLAGS"
        unset B2_CXXFLAGS
    fi
```

If $B2_CXXFLAGS hadn't started with cxxflags= , then it's just plain flags like --coverage.  Those plain flags like --coverage are added as b2 flags.   Not cxxflags.   Which breaks things.

So, an idea is to prepend a cxxflags prefix:

```
    if [ -n "$B2_CXXFLAGS" ]; then
        # Sometimes (ab)used for sanitizers, so play safe and add it to B2_FLAGS

        if [[ "$B2_CXXFLAGS" =~ "^cxxflags=.*" ]]; then
            # no action taken
            true
        else
            B2_CXXFLAGS="cxxflags=$B2_CXXFLAGS"
        fi

        B2_FLAGS="$B2_FLAGS $B2_CXXFLAGS"
        unset B2_CXXFLAGS
    fi
```

But it gets into various problems with quotes.  The final result needs to be surrounded by quotes to group everything as a cxxflag and not a b2 flag:

```
 'cxxflags=-fkeep-static-functions --coverage' 
```

A easy solution is to roll back everything.   

How were sanitizers causing abuse?    
Why is this modification only being applied to B2_CI_VERSION=0?  

I've added Flamefire to the whitelist on Drone, you could test boostorg/optional in a fork Flamefire/optional, to observe the problem, on the codecov job.

