### PR TITLE
Test & fix codecov

### DIFF
--- a/.github/workflows/old_ci.yml
+++ b/.github/workflows/old_ci.yml
@@ -1,0 +1,96 @@
+# Copyright 2020-2021 Peter Dimov
+# Copyright 2021 Andrey Semashev
+# Copyright 2021 Alexander Grund
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+
+name: Compatibility CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - develop
+      - feature/**
+
+concurrency:
+  group: ${{format('compat-{0}:{1}', github.repository, github.ref)}}
+  cancel-in-progress: true
+
+jobs:
+  posix:
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Old var usage
+            env:
+              B2_TOOLSET: gcc-8
+              B2_ADDRESS_MODEL: address-model=64
+              B2_LINK: link=shared,static
+              B2_THREADING: threading=multi,single
+              B2_VARIANT: variant=release
+              # Possible (ab)usage
+              B2_CXXFLAGS: define=norecover
+
+              B2_DEFINES: define=BOOST_NO_STRESS_TEST=1
+              B2_LINKFLAGS: linkflags=-fuse-ld=gold
+            os: ubuntu-20.04
+            install: g++-8
+          - name: Travis-like coverage collection
+            coverage: yes
+            env:
+              B2_TOOLSET: gcc-8
+              B2_CXXSTD: 03,11
+              B2_DEFINES: define=BOOST_NO_STRESS_TEST=1
+            os: ubuntu-20.04
+            install: g++-8
+          - name: Travis-like coverage collection with set CXX/LINK-flags
+            coverage: yes
+            env:
+              B2_TOOLSET: gcc-8
+              B2_CXXSTD: 03,11
+              B2_CXXFLAGS: cxxflags=-g0
+              B2_LINKFLAGS: linkflags=-fuse-ld=gold
+            os: ubuntu-20.04
+            install: g++-8
+
+    name: ${{matrix.name}}
+    timeout-minutes: 120
+    runs-on: ${{matrix.os}}
+    env: ${{matrix.env}}
+
+    steps:
+      - name: Setup environment
+        run: |
+            [ ! -f "/etc/debian_version" ] || echo "DEBIAN_FRONTEND=noninteractive" >> $GITHUB_ENV
+            git config --global pack.threads 0
+
+      - uses: actions/checkout@v2
+        if: '!matrix.coverage'
+      - uses: actions/checkout@v2
+        if: 'matrix.coverage'
+        with: { fetch-depth: 0 }
+
+      - name: Install packages
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+            sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
+            sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y ${{matrix.install}}
+
+      - name: Setup Boost
+        run: source ci/github/install.sh
+
+      - name: Run tests
+        if: '!matrix.coverage'
+        run: ci/build.sh
+
+      - name: Collect and upload coverage (old way)
+        if: matrix.coverage
+        run: ci/travis/codecov.sh

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Here are all the steps you need to take as a Boost repository maintainer to enab
 1. Copy the `.appveyor.yml` file from this repository into the *top level* of your repository.
 1. Copy the `.azure-pipelines.yml` file from this repository into the top level of your repository.
 1. Copy the `.travis.yml` file from this repository into the top level of your repository.
-1. Copy the `.github` folder from this repository into the top level of your repository.
+1. Copy the `.github/workflows/ci.yml` file from this repository into the the same folder in your repository.
 1. Copy the `.drone.star` file and `.drone` directory from this repository to the top level of your repository.
 1. Copy the `LICENSE` file from this repository to the top level of your repository.  This adds the `BSL-1.0` designation to your repository on github.
 1. [optional] Copy the `README.template.md` file from this repository to the top level `README.md` of your repository.  If you already have a README.md then you can take what you need from the template version to improve it, if desired.  Otherwise, you will need to customize README.md for your repository.  One useful step is to fixup the repository name using the command `sed -i 's/template/<myrepositoryname>/g' README.md`, and then update the first line description.

--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -22,7 +22,11 @@ set -ex
 
 if [[ "$1" == "setup" ]]; then
     export B2_VARIANT=debug
-    export B2_CXXFLAGS="${B2_CXXFLAGS:+$B2_CXXFLAGS }-fkeep-static-functions --coverage"
+    if [ -z "$B2_CI_VERSION" ]; then
+        export B2_CXXFLAGS="${B2_CXXFLAGS:+$B2_CXXFLAGS }cxxflags=-fkeep-static-functions cxxflags=--coverage"
+    else
+        export B2_CXXFLAGS="${B2_CXXFLAGS:+$B2_CXXFLAGS }-fkeep-static-functions --coverage"
+    fi
     export B2_LINKFLAGS="${B2_LINKFLAGS:+$B2_LINKFLAGS }--coverage"
 
 elif [[ "$1" == "upload" ]]; then


### PR DESCRIPTION
Improved version of #116:

Add a Regression test CI (GHA) to test "old" usages of Boost.CI
Fix the found (and reproduced) issue of the missing `cxxflags` on those.