### PR TITLE
Update appveyor config

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -78,7 +78,8 @@ environment:
 
     - FLAVOR: clang-cl
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      ADDCOMMANDS: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"'
+      # So far, this step seems to be required. Commenting out to observe the failure in CI.
+      # ADDCOMMANDS: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"'
       B2_ADDRESS_MODEL: 64
       B2_CXXSTD: 11,14,17
       B2_TOOLSET: clang-win
@@ -95,7 +96,6 @@ environment:
     - FLAVOR: cygwin (32-bit)
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       ADDPATH: C:\cygwin\bin;
-      ADDCOMMANDS: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat"'
       B2_ADDRESS_MODEL: 32
       B2_CXXSTD: 03,11,14,1z
       B2_TOOLSET: gcc
@@ -103,7 +103,6 @@ environment:
     - FLAVOR: cygwin (64-bit)
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       ADDPATH: C:\cygwin64\bin;
-      ADDCOMMANDS: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"'
       B2_ADDRESS_MODEL: 64
       B2_CXXSTD: 03,11,14,1z
       B2_TOOLSET: gcc
@@ -112,14 +111,18 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       B2_ADDRESS_MODEL: 32
       ADDPATH: C:\mingw\bin;
-      B2_CXXSTD: 11,14,17,2a
+      # It seems 03 isn't supported. Leaving it in for the moment, to show errors in CI.
+      # B2_CXXSTD: 11,14,17,2a
+      B2_CXXSTD: 03,11,14,17,2a
       B2_TOOLSET: gcc
 
     - FLAVOR: mingw64
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       ADDPATH: C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;
       B2_ADDRESS_MODEL: 64
-      B2_CXXSTD: 11,14,17,2a
+      # It seems 03 isn't supported. Leaving it in for the moment, to show errors in CI.
+      # B2_CXXSTD: 11,14,17,2a
+      B2_CXXSTD: 03,11,14,17,2a
       B2_TOOLSET: gcc
 
 install:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -53,16 +53,22 @@ environment:
     B2_VARIANT: release
 
   matrix:
+    - FLAVOR: Visual Studio 2022
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      B2_CXXFLAGS: -permissive-
+      B2_CXXSTD: 14,17,20
+      B2_TOOLSET: msvc-14.3
+
     - FLAVOR: Visual Studio 2019
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       B2_CXXFLAGS: -permissive-
-      B2_CXXSTD: 14,17,latest # 2a
+      B2_CXXSTD: 14,17,2a
       B2_TOOLSET: msvc-14.2
 
     - FLAVOR: Visual Studio 2017 C++2a Strict
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       B2_CXXFLAGS: -permissive-
-      B2_CXXSTD: latest # 2a
+      B2_CXXSTD: 2a
       B2_TOOLSET: msvc-14.1
 
     - FLAVOR: Visual Studio 2017 C++14/17

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -77,7 +77,8 @@ environment:
       B2_TOOLSET: msvc-14.1
 
     - FLAVOR: clang-cl
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      ADDCOMMANDS: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"'
       B2_ADDRESS_MODEL: 64
       B2_CXXSTD: 11,14,17
       B2_TOOLSET: clang-win
@@ -92,15 +93,17 @@ environment:
       B2_ADDRESS_MODEL: 32 # No 64bit support
 
     - FLAVOR: cygwin (32-bit)
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       ADDPATH: C:\cygwin\bin;
+      ADDCOMMANDS: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat"'
       B2_ADDRESS_MODEL: 32
       B2_CXXSTD: 03,11,14,1z
       B2_TOOLSET: gcc
 
     - FLAVOR: cygwin (64-bit)
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       ADDPATH: C:\cygwin64\bin;
+      ADDCOMMANDS: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"'
       B2_ADDRESS_MODEL: 64
       B2_CXXSTD: 03,11,14,1z
       B2_TOOLSET: gcc
@@ -109,17 +112,18 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       B2_ADDRESS_MODEL: 32
       ADDPATH: C:\mingw\bin;
-      B2_CXXSTD: 03,11,14,17,2a
+      B2_CXXSTD: 11,14,17,2a
       B2_TOOLSET: gcc
 
     - FLAVOR: mingw64
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       ADDPATH: C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;
       B2_ADDRESS_MODEL: 64
-      B2_CXXSTD: 03,11,14,17,2a
+      B2_CXXSTD: 11,14,17,2a
       B2_TOOLSET: gcc
 
 install:
+  - '%ADDCOMMANDS%'
   - git clone --depth 1 https://github.com/boostorg/boost-ci.git C:\boost-ci-cloned
   # Copy ci folder if not testing Boost.CI
   - if NOT "%APPVEYOR_PROJECT_NAME%" == "boost-ci" xcopy /s /e /q /i /y C:\boost-ci-cloned\ci .\ci

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -106,17 +106,17 @@ environment:
       B2_TOOLSET: gcc
 
     - FLAVOR: mingw32
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       B2_ADDRESS_MODEL: 32
       ADDPATH: C:\mingw\bin;
-      B2_CXXSTD: 03,11,14,1z
+      B2_CXXSTD: 03,11,14,17,2a
       B2_TOOLSET: gcc
 
     - FLAVOR: mingw64
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      ADDPATH: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      ADDPATH: C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;
       B2_ADDRESS_MODEL: 64
-      B2_CXXSTD: 03,11,14,1z
+      B2_CXXSTD: 03,11,14,17,2a
       B2_TOOLSET: gcc
 
 install:

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -14,6 +14,7 @@
 #include <boost/boost-ci/boost_ci.hpp>
 // And the usual test framwork
 #include <boost/core/lightweight_test.hpp>
+#include "test2.hpp"
 
 int main()
 {

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -14,6 +14,7 @@
 #include <boost/boost-ci/boost_ci.hpp>
 // And the usual test framwork
 #include <boost/core/lightweight_test.hpp>
+// Check that including a file from the same directory works
 #include "test2.hpp"
 
 int main()

--- a/test/test2.hpp
+++ b/test/test2.hpp
@@ -1,0 +1,9 @@
+//
+// Copyright (c) 2020 Mateusz Loskot <mateusz@loskot.net>
+//
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+// test


### PR DESCRIPTION
- Add a Visual Studio 2022 job
- Specify 2a or 20, instead of "latest".  The difficulty with "latest" is I think now they are starting to move past version 20 and could include experimental or beta features.
- Change mingw image to Visual Studio 2019

Still running validation tests. will report back if there's anything else.
