### PR TITLE
Make sure braces are correctly excluded from coverage

### DIFF
--- a/ci/codecov.ps1
+++ b/ci/codecov.ps1
@@ -49,7 +49,7 @@ $exclusions = @(
   '.*// LCOV_EXCL_LINE'
   '.*// coverity\[dead_error_line\]'
   # Lines containing only braces
-  '\s*[{}]*\s*'
+  '\s*[}{]*\s*'
   # Lines containing only else (and opt. braces)
   '\s*(\} )?else( \{)?\s*'
 )

--- a/include/boost/boost-ci/boost_ci.hpp
+++ b/include/boost/boost-ci/boost_ci.hpp
@@ -27,9 +27,12 @@ namespace boost
       int answer;
       // Specifically crafted condition to check for coverage from MSVC and non MSVC builds
       if(isMsvc)
+      {
         answer = 21;
-      else
+      } else
+      {
         answer = 42;
+      }
 #ifdef BOOST_NO_CXX11_SMART_PTR
       return answer;
 #else

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -24,9 +24,12 @@ int main()
     map["result"].push_back(boost::boost_ci::get_answer());
     // Specifically crafted condition to check for coverage from MSVC and non MSVC builds
     if(isMSVC)
+    {
       BOOST_TEST_EQ(boost::boost_ci::get_answer(), 21);
-    else
+    } else
+    {
       BOOST_TEST_EQ(boost::boost_ci::get_answer(), 42);
+    }
     BOOST_TEST_EQ(map["result"].size(), 1u);
     return boost::report_errors();
 }


### PR DESCRIPTION
PS seemingly parses "{}", so switch to "}{" in the RegExp character group to avoid this.
Add a few braces in the sources for testing