### PR TITLE
properly quote github ci.yml windows matrix addrmd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,10 +194,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { toolset: msvc-14.1, cxxstd: '14,17,latest',   addrmd: 32,64, os: windows-2016 }
-          - { toolset: msvc-14.2, cxxstd: '14,17,20',       addrmd: 32,64, os: windows-2019 }
-          - { toolset: msvc-14.3, cxxstd: '14,17,20',       addrmd: 32,64, os: windows-2022 }
-          - { toolset: gcc,       cxxstd: '03,11,14,17,2a', addrmd: 64,    os: windows-2019 }
+          - { toolset: msvc-14.1, cxxstd: '14,17,latest',   addrmd: '32,64', os: windows-2016 }
+          - { toolset: msvc-14.2, cxxstd: '14,17,20',       addrmd: '32,64', os: windows-2019 }
+          - { toolset: msvc-14.3, cxxstd: '14,17,20',       addrmd: '32,64', os: windows-2022 }
+          - { toolset: gcc,       cxxstd: '03,11,14,17,2a', addrmd: '64',    os: windows-2019 }
 
     runs-on: ${{matrix.os}}
 


### PR DESCRIPTION
NOTE: jobs will start failing in March 2022 when the windows-2016 runner is removed from GitHub Actions.