### PR TITLE
add coverity support for github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 # Copyright 2020-2021 Peter Dimov
 # Copyright 2021 Andrey Semashev
 # Copyright 2021 Alexander Grund
+# Copyright 2022 James E. King III
 #
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
-
+---
 name: CI
 
 on:
@@ -66,13 +67,14 @@ jobs:
           - { compiler: clang-5.0, cxxstd: '03,11,14,1z',    os: ubuntu-18.04 }
           - { compiler: clang-6.0, cxxstd: '03,11,14,17',    os: ubuntu-18.04 }
           - { compiler: clang-7,   cxxstd: '03,11,14,17',    os: ubuntu-18.04 }
-            # Note: clang-8 does not fully support C++20, so it is not compatible with some libstdc++ versions in this mode
+          # Note: clang-8 does not fully support C++20, so it is not compatible with some libstdc++ versions in this mode
           - { compiler: clang-8,   cxxstd: '03,11,14,17,2a', os: ubuntu-18.04, install: 'clang-8 g++-7', gcc_toolchain: 7 }
           - { compiler: clang-9,   cxxstd: '03,11,14,17,2a', os: ubuntu-20.04 }
           - { compiler: clang-10,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
           - { compiler: clang-11,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
           - { compiler: clang-12,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
-            # libc++
+
+          # libc++
           - { compiler: clang-6.0, cxxstd: '03,11,14',       os: ubuntu-18.04, stdlib: libc++, install: 'clang-6.0 libc++-dev libc++abi-dev' }
           - { compiler: clang-12,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04, stdlib: libc++, install: 'clang-12 libc++-12-dev libc++abi-12-dev' }
           - { name: Clang w/ sanitizers, sanitize: yes,
@@ -80,6 +82,12 @@ jobs:
 
           # OSX, clang
           - { compiler: clang,     cxxstd: '03,11,14,17,2a', os: macos-10.15, sanitize: yes }
+
+          # Coverity Scan
+          # requires two github secrets in repo to activate; see ci/github/coverity.sh
+          # does not run on pull requests, only on pushes into develop and master
+          - { name: Coverity, coverity: yes,
+              compiler: clang-10,  cxxstd: '17',             os: ubuntu-20.04 }
 
     timeout-minutes: 120
     runs-on: ${{matrix.os}}
@@ -101,6 +109,9 @@ jobs:
                 apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
                 apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y g++ python libpython-dev git
             fi
+            if [ ! -z "${{ matrix.coverity }}" ]; then
+                echo "B2_USE_CCACHE=0" >> $GITHUB_ENV
+            fi
             git config --global pack.threads 0
 
       - uses: actions/checkout@v2
@@ -112,6 +123,7 @@ jobs:
 
       - name: Cache ccache
         uses: actions/cache@v2
+        if: env.B2_USE_CCACHE
         with:
           path: ~/.ccache
           key: ${{matrix.os}}-${{matrix.container}}-${{matrix.compiler}}
@@ -180,11 +192,19 @@ jobs:
         run: ci/github/codecov.sh "setup"
 
       - name: Run tests
+        if: '!matrix.coverity'
         run: ci/build.sh
 
       - name: Upload coverage
         if: matrix.coverage
         run: ci/codecov.sh "upload"
+
+      - name: Run coverity
+        if: matrix.coverity && github.event_name == 'push'
+        run: ci/github/coverity.sh
+        env:
+          COVERITY_SCAN_NOTIFICATION_EMAIL: ${{ secrets.COVERITY_SCAN_NOTIFICATION_EMAIL }}
+          COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
 
   windows:
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
                 apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
                 apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y g++ python libpython-dev git
             fi
-            if [ ! -z "${{ matrix.coverity }}" ]; then
+            if [[ "${{ matrix.coverity }}" == "yes" ]]; then
                 echo "B2_USE_CCACHE=0" >> $GITHUB_ENV
             fi
             git config --global pack.threads 0
@@ -200,7 +200,7 @@ jobs:
         run: ci/codecov.sh "upload"
 
       - name: Run coverity
-        if: matrix.coverity && github.event_name == 'push'
+        if: matrix.coverity && github.event_name == 'push' && (github.ref_name == 'develop' || github.ref_name == 'master')
         run: ci/github/coverity.sh
         env:
           COVERITY_SCAN_NOTIFICATION_EMAIL: ${{ secrets.COVERITY_SCAN_NOTIFICATION_EMAIL }}

--- a/ci/common_install.sh
+++ b/ci/common_install.sh
@@ -18,8 +18,11 @@
 # - BOOST_CI_TARGET_BRANCH
 # - BOOST_CI_SRC_FOLDER
 # - GIT_FETCH_JOBS to fetch in parallel
+#
 # Will set:
+# - BOOST_BRANCH
 # - BOOST_ROOT
+# - SELF
 
 set -ex
 

--- a/ci/enforce.sh
+++ b/ci/enforce.sh
@@ -19,6 +19,8 @@ function enforce_b2
         if [ -n "${!old_varname}" ]; then
             if [ "$TRAVIS" = "true" ]; then
                 local ci_script=".travis.yml"
+            elif [ ! -z "${GITHUB_WORKFLOW}" ]; then
+                local ci_script="${GITHUB_WORKFLOW} workflow"
             elif [ -n "$AGENT_OS" ]; then
                 local ci_script=".azure-pipelines.yml or azure-pipelines.yml"
             fi

--- a/ci/github/coverity.sh
+++ b/ci/github/coverity.sh
@@ -1,0 +1,57 @@
+#! /bin/bash
+#
+# Copyright 2017 - 2022 James E. King III
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+#      http://www.boost.org/LICENSE_1_0.txt)
+#
+# Bash script to run in GHA to perform a Coverity Scan build
+# Environment Variables you must define (as secrets in GHA):
+#
+# COVERITY_SCAN_NOTIFICATION_EMAIL  - email address to notify
+# COVERITY_SCAN_TOKEN               - the Coverity Scan token (should be secure)
+#
+
+set -ex
+
+# install.sh will call common_install.sh in a previous CI step and write CXX 
+# out to a file but it isn't available in subsequent CI steps, so pick it up
+CXX=$(cat ~/user-config.jam | cut -d' ' -f5)
+
+if [[ "${CXX}" != "clang"* ]]; then
+  echo "GHA CI Coverity jobs only support clang toolsets right now."
+  exit 1
+fi
+
+if [[ -z "${COVERITY_SCAN_TOKEN}" || -z "${COVERITY_SCAN_NOTIFICATION_EMAIL}" ]]; then
+  echo "GHA CI Coverity jobs require COVERITY_SCAN_TOKEN and COVERITY_SCAN_NOTIFICATION_EMAIL secrets."
+  exit 1
+fi
+
+sudo wget -nv https://entrust.com/root-certificates/entrust_l1k.cer -O /tmp/scanca.cer
+
+pushd /tmp
+rm -rf coverity_tool.tgz cov-analysis*
+curl --cacert /tmp/scanca.cer -L -d "token=${COVERITY_SCAN_TOKEN}&project=${GITHUB_REPOSITORY}" -X POST https://scan.coverity.com/download/cxx/linux64 -o coverity_tool.tgz
+tar xzf coverity_tool.tgz
+COVBIN=$(echo $(pwd)/cov-analysis*/bin)
+export PATH=${COVBIN}:${PATH}
+popd
+
+RESULTS_DIR="$(pwd)/cov-int"
+mkdir "${RESULTS_DIR}"
+cov-configure --template --compiler "${CXX}" --comptype "clangcxx"
+unset CXX
+
+cov-build --dir "${RESULTS_DIR}" ci/build.sh
+
+ls -ls "${RESULTS_DIR}"
+tail -50 "${RESULTS_DIR}/build-log.txt"
+tar czf cov-int.tgz cov-int
+curl --cacert /tmp/scanca.cer \
+     --form token="${COVERITY_SCAN_TOKEN}" \
+     --form email="${COVERITY_SCAN_NOTIFICATION_EMAIL}" \
+     --form file=@cov-int.tgz \
+     --form version="${GITHUB_REF_NAME}" \
+     --form description="${GITHUB_REPOSITORY}:${GITHUB_REF}:${GITHUB_SHA}:${GITHUB_RUN_NUMBER}" \
+     https://scan.coverity.com/builds?project="${GITHUB_REPOSITORY}"


### PR DESCRIPTION
This change adds Coverity Scan integration.
It requires two GitHub Secrets in your repository.

I created a Coverity Scan project for boost-ci so we can test this is isolation.
I added GitHub Secrets COVERITY_SCAN_NOTIFICATION_EMAIL and COVERITY_SCAN_TOKEN to the repo.

Note that there is no way to disable a matrix run at the job level (easily).  I configured it so coverity does not run on pull requests, only on pushes into develop, master, and feature/* branches by default.  Therefore, in the checks for this pull request you will see a Coverity job that completes, but it does not submit anything as the Coverity step is skipped in pull requests.  I also pushed a feature branch called feature/coverity, which does push results.  Here's the fully enabled job in that branch push: https://github.com/boostorg/boost-ci/runs/5013565237?check_suite_focus=true, and here's a link to Coverity where it uploaded: https://scan.coverity.com/projects/boostorg-boost-ci?tab=overview

To eliminate the coverity job on pull requests I would have to copy most of the posix job steps into their own coverity job, and I figured that level of step code duplication without GHA support for YAML anchors would be less than awesome.  So this is the best compromise.

I also did more work to allow ccache to be fully disabled; this is important because I could not get coverity to work correctly with ccache running before the compiler (I tried at least 20 times with different options and whatnot).