### PR TITLE
Combine the 2 checkout steps on GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,12 +121,9 @@ jobs:
             git config --global pack.threads 0
 
       - uses: actions/checkout@v2
-        if: '!matrix.coverage'
-
-      - uses: actions/checkout@v2
-        if: 'matrix.coverage'
         with:
-          fetch-depth: 0
+          # For coverage builds fetch the whole history, else only 1 commit using a 'fake ternary'
+          fetch-depth: ${{ matrix.coverage && '0' || '1' }}
 
       - name: Cache ccache
         uses: actions/cache@v2


### PR DESCRIPTION
Better solution IMO as it doesn't turn up as 2 steps in the CI run.

See https://github.com/actions/runner/issues/409 about the workaround for the missing ternary operator.