### PR TITLE
fixup coverage invocation and calculation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           - { name: GCC w/ sanitizers, sanitize: yes,
               compiler: gcc-11,    cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
           - { name: Collect coverage, coverage: yes,
-              compiler: gcc-8,     cxxstd: '03,11',          os: ubuntu-20.04, install: 'g++-8-multilib', address-model: '32,64' }
+              compiler: gcc-10,    cxxstd: '03,11',          os: ubuntu-20.04, install: 'g++-10-multilib', address-model: '32,64' }
 
           # Linux, clang
           - { compiler: clang-3.5, cxxstd: '03,11',          os: ubuntu-20.04, container: 'ubuntu:16.04' }

--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -23,51 +23,69 @@ set -ex
 if [[ "$1" == "setup" ]]; then
     export B2_VARIANT=debug
     if [ -z "$B2_CI_VERSION" ]; then
-        export B2_CXXFLAGS="${B2_CXXFLAGS:+$B2_CXXFLAGS }cxxflags=-fkeep-static-functions cxxflags=--coverage"
+        export B2_CXXFLAGS="${B2_CXXFLAGS:+$B2_CXXFLAGS }cxxflags=-fprofile-arcs cxxflags=-ftest-coverage cxxflags=--coverage"
     else
-        export B2_CXXFLAGS="${B2_CXXFLAGS:+$B2_CXXFLAGS }-fkeep-static-functions --coverage"
+        export B2_CXXFLAGS="${B2_CXXFLAGS:+$B2_CXXFLAGS }-fprofile-arcs -ftest-coverage --coverage"
     fi
     export B2_LINKFLAGS="${B2_LINKFLAGS:+$B2_LINKFLAGS }--coverage"
 
 elif [[ "$1" == "upload" ]]; then
     if [ -z "$GCOV" ]; then
-        ver=7 # default
-        if [ "${B2_TOOLSET%%-*}" == "gcc" ]; then
-            if [[ "$B2_TOOLSET" =~ gcc- ]]; then
-                ver="${B2_TOOLSET##*gcc-}"
-            elif [[ "$B2_COMPILER" =~ gcc- ]]; then
-                ver="${B2_COMPILER##*gcc-}"
+        # enforce.sh ensures B2_COMPILER
+        COMPILER=${B2_COMPILER}
+        COMPILER_FAMILY=$(echo ${COMPILER} | cut -d'-' -f1)
+        COMPILER_EDITION=$(echo ${COMPILER} | cut -d'-' -f2)
+        # clang is still not working - need a llvm-cov wrapper and fixup pathing
+        if [ "${COMPILER_FAMILY}" == "clang" ]; then
+            echo "clang is not supported for coverage yet"
+            exit 1
+            # find /usr/lib -name 'llvm-cov*' -print
+            # LLVM_COV_PATH=$(find /usr/lib -type f -name llvm-cov -exec dirname {} \;)
+            # export PATH=${LLVM_COV_PATH}:${PATH}
+            # GCOV=llvm-cov
+        elif [ "${COMPILER_FAMILY}" == "gcc" ]; then
+            # cutting "gcc" above yields "gcc" for both values if no version present
+            if [ "${COMPILER_EDITION}" == "${COMPILER_FAMILY}" ]; then
+                GCOV=gcov
+            else
+                GCOV=gcov-${COMPILER_EDITION}
             fi
+        else
+            echo "Cannot determine GCOV."
+            exit 1
         fi
-        GCOV=gcov-${ver}
     fi
 
     # install the latest lcov we know works
     rm -rf /tmp/lcov
     cd /tmp
-    git clone --depth 1 -b v1.14 https://github.com/linux-test-project/lcov.git
+    git clone --depth 1 -b v1.15 https://github.com/linux-test-project/lcov.git
     export PATH=/tmp/lcov/bin:$PATH
     command -v lcov
     lcov --version
 
     # switch back to the original source code directory
     cd $BOOST_CI_SRC_FOLDER
-    : "${LCOV_BRANCH_COVERAGE:=1}" # Set default
+    : "${LCOV_BRANCH_COVERAGE:=1}" # On by default, job can override but advise against it
 
     # coverage files are in ../../b2 from this location
-    lcov --gcov-tool=$GCOV --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE} --base-directory "$BOOST_ROOT/libs/$SELF" --directory "$BOOST_ROOT" --capture --output-file all.info
-    # dump a summary on the console
-    lcov --list all.info
+    lcov --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE} --gcov-tool=${GCOV} --directory "${BOOST_ROOT}" --capture --output-file all.info
+    lcov --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE} --list all.info  # mostly for debug but interesting to see everything captured
 
-    # all.info contains all the coverage info for all projects - limit to ours
-    # first we extract the interesting headers for our project then we use that list to extract the right things
+    # this is tricky; not all of the headers in the project go into a directory with the project
+    # name, so we have to itemize all of them and extract them, along with anything in the project
+    # directory including tests - after this we drop coverage on test files to finalize things
     for f in `for f in include/boost/*; do echo $f; done | cut -f2- -d/`; do echo "*/$f*"; done > /tmp/interesting
     echo headers that matter:
     cat /tmp/interesting
-    xargs -L 999999 -a /tmp/interesting lcov --gcov-tool=$GCOV --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE:-1} --extract all.info {} "*/libs/$SELF/*" --output-file coverage.info
+    xargs -L 999999 -a /tmp/interesting lcov --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE} --extract all.info {} "*/libs/$SELF/*" --output-file "${SELF}-all.info"
+    lcov --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE} --list "${SELF}-all.info"
 
-    # dump a summary on the console - helps us identify problems in pathing
-    lcov --list coverage.info
+    # drop coverage on test files
+    lcov --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE} --remove "${SELF}-all.info" "*/${SELF}/test/*" -o "coverage.info"
+
+    # dump a summary on the console
+    lcov --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE} --list coverage.info
 
     #
     # upload to codecov.io


### PR DESCRIPTION
- Changed the default coverage compiler to gcc-10.
- Fixed coverage cxxflags.
- Fixed detection of gcov when compiler if set to `gcc`.
- Explicitly fail for clang, for now - llvm-cov needs a wrapper and other work.
- Bump lcov to v1.15
- Fix branch coverage analysis by setting it for every lcov invocation otherwise it gets dropped.

Here is a build job I cobbled together to show the changes:

https://github.com/boostorg/uuid/actions/runs/1789529870