### PR TITLE
minor coverage cleanup - update lcov

### DIFF
--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-# Copyright 2017 - 2019 James E. King III
+# Copyright 2017 - 2022 James E. King III
 # Copyright 2021 Alexander Grund
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
@@ -15,6 +15,13 @@
 # - BOOST_ROOT
 # - SELF
 # Call with either "setup" or "upload" as parameter
+
+#
+# If you want to exclude content from the coverage report you must check in
+# a .codecov.yml file as is found in the boost-ci project, and it must be
+# in the default branch for the repository.  It will not be picked up from
+# a pull request.
+#
 
 set -ex
 
@@ -45,7 +52,7 @@ elif [[ "$1" == "upload" ]]; then
     # install the latest lcov we know works
     rm -rf /tmp/lcov
     cd /tmp
-    git clone --depth 1 -b v1.14 https://github.com/linux-test-project/lcov.git
+    git clone --depth 1 -b v1.15 https://github.com/linux-test-project/lcov.git
     export PATH=/tmp/lcov/bin:$PATH
     command -v lcov
     lcov --version
@@ -55,19 +62,23 @@ elif [[ "$1" == "upload" ]]; then
     : "${LCOV_BRANCH_COVERAGE:=1}" # Set default
 
     # coverage files are in ../../b2 from this location
-    lcov --gcov-tool=$GCOV --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE} --base-directory "$BOOST_ROOT/libs/$SELF" --directory "$BOOST_ROOT" --capture --output-file all.info
+    lcov --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE} --gcov-tool=$GCOV --directory "$BOOST_ROOT" --capture --output-file all.info
     # dump a summary on the console
-    lcov --list all.info
+    lcov --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE} --list all.info
 
     # all.info contains all the coverage info for all projects - limit to ours
     # first we extract the interesting headers for our project then we use that list to extract the right things
     for f in `for f in include/boost/*; do echo $f; done | cut -f2- -d/`; do echo "*/$f*"; done > /tmp/interesting
     echo headers that matter:
     cat /tmp/interesting
-    xargs -L 999999 -a /tmp/interesting lcov --gcov-tool=$GCOV --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE:-1} --extract all.info {} "*/libs/$SELF/*" --output-file coverage.info
+    xargs -L 999999 -a /tmp/interesting lcov --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE} --extract all.info {} "*/libs/$SELF/*" --output-file coverage.info
 
     # dump a summary on the console - helps us identify problems in pathing
-    lcov --list coverage.info
+    # note this has test file coverage in it - if you do not want to count test
+    # files against your coverage numbers then use a .codecov.yml file which
+    # must be checked into the default branch (it is not read or used from a
+    # pull request)
+    lcov --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE} --list coverage.info
 
     #
     # upload to codecov.io
@@ -91,7 +102,7 @@ elif [[ "$1" == "upload" ]]; then
     fi
 
     chmod +x codecov
-    ./codecov --verbose --nonZero ${CODECOV_NAME:+--name "$CODECOV_NAME"}
+    ./codecov --verbose --nonZero ${CODECOV_NAME:+--name "$CODECOV_NAME"} -f coverage.info -X search
 else
     echo "Invalid parameter for codecov.sh: '$1'." >&2
     false


### PR DESCRIPTION
- Update lcov to v1.15 to avoid issues locating files
- Set lcov_branch_coverage in all lcov commands so branch coverage is not lost
- Ensure the codecov binary can find the coverage.info file
- Removed the `base-directory` from lcov capture - it is unnecessary as all files are copied into `directory` before we build, and may have contributed to issues locating files when updating to lcov 1.15

A run in uuid using this branch shows it properly omits the test code from coverage (it was not possible to do this with .codecov.yml with sevaral attempts):

https://github.com/boostorg/uuid/pull/132
https://github.com/boostorg/uuid/runs/5061829179?check_suite_focus=true#step:13:501
https://codecov.io/gh/boostorg/uuid/tree/774fcc1864bd697c0110f56711018c13bcf380ee

I made the changes as unintrusive and backwards-compatible as possible to avoid regressions.