### PR TITLE
Docu update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,10 @@ on:
     branches:
       - master
       - develop
+      - bugfix/**
       - feature/**
+      - fix/**
+      - pr/**
 
 concurrency:
   group: ${{format('{0}:{1}', github.repository, github.ref)}}

--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
 ![Boost](images/boost.png  "Boost")
 
-# Boost.CI #
+# Boost.CI
 
-This repository contains scripts that enable continuous integration with [Appveyor](https://www.appveyor.com/),
-[Azure Pipelines](https://github.com/marketplace/azure-pipelines), [codecov.io](https://codecov.io/),
-[Coverity Scan](https://scan.coverity.com/), [GitHub Actions](https://github.com/features/actions), [Drone](https://drone.io/), and [Travis CI](https://travis-ci.org/).
+This repository contains scripts that enable continuous integration (CI) with
+[Appveyor](https://www.appveyor.com/),
+[Azure Pipelines](https://github.com/marketplace/azure-pipelines),
+[codecov.io](https://codecov.io/),
+[Coverity Scan](https://scan.coverity.com/),
+[GitHub Actions](https://github.com/features/actions),
+[Drone](https://drone.io/),
+and [Travis CI](https://travis-ci.org/).
 These scripts are intended to be downloaded and used during boost repository builds to improve project quality.
-In most cases the scripts are self-configuring.  Some integrations require additional setup actions to complete.
+In most cases the scripts are self-configuring.
+Some integrations require additional setup actions to complete.
 
-Boost.CI also allows you to run a big-endian build on Travis CI.
+Boost.CI also allows you to run a big-endian build on Travis CI and Github Actions.
 
 ### Build Status
 
@@ -16,9 +22,10 @@ GH Actions | Appveyor | Azure Pipelines | Drone | codecov.io |
 ---------- | -------- | --------------- | ----- | ---------- |
 [![Build status](https://github.com/boostorg/boost-ci/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/boostorg/boost-ci/actions/workflows/ci.yml) | [![Build status](https://ci.appveyor.com/api/projects/status/ynnd2l3gu4oiyium/branch/master?svg=true)](https://ci.appveyor.com/project/Flamefire/boost-ci/branch/master) | [![Build Status](https://dev.azure.com/boostorg/boost-ci/_apis/build/status/boostorg.boost-ci?branchName=master)](https://dev.azure.com/boostorg/boost-ci/_build/latest?definitionId=8&branchName=master) | [![Build Status](https://drone.cpp.al/api/badges/boostorg/boost-ci/status.svg)](https://drone.cpp.al/boostorg/boost-ci) |  [![codecov](https://codecov.io/gh/boostorg/boost-ci/branch/master/graph/badge.svg)](https://codecov.io/gh/boostorg/boost-ci/branch/master) | 
 
-## Summary (TL;DR) ##
+## Summary (TL;DR)
 
-Here are all the steps you need to take as a Boost repository maintainer to enable all of these CI features in your repository:
+Here are all the steps you need to take as a Boost repository maintainer to enable all of these CI features in your repository.
+(Note that you may skip some steps, e.g. if you don't need a specific CI service):
 
 1. Checkout `develop` and then make a new branch called `ci`.
 1. Copy the `.appveyor.yml` file from this repository into the *top level* of your repository.
@@ -26,22 +33,22 @@ Here are all the steps you need to take as a Boost repository maintainer to enab
 1. Copy the `.travis.yml` file from this repository into the top level of your repository.
 1. Copy the `.github/workflows/ci.yml` file from this repository into the the same folder in your repository.
 1. Copy the `.drone.star` file and `.drone` directory from this repository to the top level of your repository.
-1. Copy the `.codecov.yml` file from this repository to the top level of your repository and edit if required.
+1. Copy the `.codecov.yml` file from this repository to the top level of your repository and edit if required. Note that **only** the file in the default branch (usually `master`) is considered!
 1. Copy the `LICENSE` file from this repository to the top level of your repository.  This adds the `BSL-1.0` designation to your repository on github.
 1. [optional] Copy the `README.template.md` file from this repository to the top level `README.md` of your repository.  If you already have a README.md then you can take what you need from the template version to improve it, if desired.  Otherwise, you will need to customize README.md for your repository.  One useful step is to fixup the repository name using the command `sed -i 's/template/<myrepositoryname>/g' README.md`, and then update the first line description.
 1. In Appveyor, add a project for your fork of the repository.  No customization is needed.
 1. In Travis CI, add a project for your fork of the repository.  Later you will customize it for Coverity Scan, but for now no settings changes are necessary.
 1. Commit these changes and push to your personal fork in the ci branch.
 1. Create a pull request in your fork of <myrepositoryname>/ci to <myrepositoryname>/develop.  Do not target boostorg/develop.
-1. Observe that both Appveyor and Travis CI are running the build jobs.  Fix up any issues found.  Note this may uncover defects in your repository code.
+1. Observe that the CI services are running the build jobs.  Fix up any issues found.  Note this may uncover defects in your repository code.
 1. If you are the owner or an admin for your repository, add projects in Appveyor and Travis CI for the boostorg/<myrepositoryname> project (not your fork).  If you are just a contributor in the repository, create an [issue in Boost.Admin](https://github.com/boostorg/admin/issues) requesting Appveyor and Travis CI to be enabled for the repository.
-1. Commit the changes to develop.  This will kick off a build on Appveyor and Travis.
-1. Update the badge matrix in README.md with the correct links for your Appveyor and Travis CI projects.
+1. Commit the changes to develop.  This will kick off a build.
+1. Update the badge matrix in README.md with the correct links for your CI projects in use (e.g. Appveyor, Github Actions, Travis).
 1. Create a Coverity Scan account if you have not already done so.
 1. Create a new Coverity Scan github based project for your official boostorg repository.
-1. Update your Travis CI boostorg repository project settings and add the following environment variables using the Travis CI GUI:
+1. Update your Travis CI and/or Github Actions boostorg repository project settings and add the following environment variables using respective CI GUI:
     * `COVERITY_SCAN_NOTIFICATION_EMAIL` can be public and set to your email account (or it can be private).
-    * `COVERITY_SCAN_TOKEN` should be kept private and set to the scan token you can find in the project settings in Coverity Scan.
+    * `COVERITY_SCAN_TOKEN` should be kept private (aka. "secret") and set to the scan token you can find in the project settings in Coverity Scan.
 1. Update the README.md to put the correct Coverity Scan badge project number into the badge URLs.
 1. This will kick off a build on the develop branch that will include Coverity Scan results.
 1. To activate Drone, visit https://drone.cpp.al. Authorize Drone: Click the "Authorize cppalliance-drone" button. Sync repositories: Click the "sync" button. A list of repositories will appear. For the relevant repo, click and then choose "Activate Repository". In the settings page, change Configuration from .drone.yml to .drone.star. "Save".
@@ -51,23 +58,44 @@ Here are all the steps you need to take as a Boost repository maintainer to enab
     * If not using asan, simply remove the jobs.
     * Further info available at https://github.com/CPPAlliance/drone-ci
 
-## Repositories using Boost.CI ###
+## Code coverage
+
+Multiple CI configs contain jobs collecting code coverage data.
+E.g. Github Actions and Drone CI for Linux and Appveyor for Windows.
+Especially the latter allows to collect coverage data for Windows-only codeparts or code using e.g. `wchar_t` which is different on Windows than on other platforms.
+
+### Exclusion of coverage data
+
+If you want to exclude parts of your code from coverage analysis you can use the LCOV comments/macros:
+
+- `// LCOV_EXCL_LINE` for a single line
+- `// LCOV_EXCL_START` and `// LCOV_EXCL_STOP` for a range of code
+
+See the LCov manual for more information.
+
+To exclude whole files or folders you can use the `ignore`-object and glob patterns in in the `.codecov.yml` file.
+See the example file in the root of this repository for a starting point.   
+**Important**: Codecov only considers the configuration file of the *default* branch (usually: `master`), **not** the one in the current build/PR branch.
+See the [CodeCov documentation](https://docs.codecov.com/docs/codecov-yaml) for details.
+
+## Repositories using Boost.CI
 
 The [CMT Stale Repo Tracker](https://travis-ci.org/jeking3/boost-merge-reminder) identifies many repositories using Boost.CI and
 the [CMT Status Spreadsheet](https://docs.google.com/spreadsheets/d/1aFdTMdJmmD9L5IyvJx-nj3BrMVztmlNo8QwyEzLD2io/edit?usp=sharing) shows the current state of each.
 There may be additional repositories using Boost.CI that are not listed.  Boost.CI does not track usage internally.
 
-## How It Works ##
+## How It Works
 
-The files `.appveyor.yml`, `.azure-pipeline.yml` and `.travis.yml` must exist in your repository and will contain your customizations for build types, languages, and platforms.  The templates provided will get you started with the build jobs listed below.
+The CI config files (such as `.appveyor.yml`, `.azure-pipeline.yml` and `.github/workflows/ci.yml`) must exist in your repository and will contain your customizations for build types, languages, and platforms.
+The templates provided will get you started with the build jobs listed below.
 
 These scripts will copy resources from the Boost.CI repository when needed in order to provide scripting necessary to run all these jobs successfully.
 
 Build jobs that will severely impact performance (such as `valgrind`) will define `BOOST_NO_STRESS_TEST` so those can be skipped or hobbled.
 
-## Topic Branch Support ##
+## Topic Branch Support
 
-The configuration for Travis CI, Github Actions, Azure Pipelines and Appveyor allow for automated branch builds on branch pushes matching these names:
+The configuration for Github Actions, Azure Pipelines, Appveyor and Travis CI allow for automated branch builds on branch pushes matching these names:
 
 - master
 - develop
@@ -76,15 +104,17 @@ The configuration for Travis CI, Github Actions, Azure Pipelines and Appveyor al
 - fix/*
 - pr/*
 
-## Defaults, Builds and Services ##
+## Defaults, Builds and Services
 
-By default all of the builds target C++11 unless otherwise specified.
-To see what kind of coverage these builds provide, see some build results:
+By default the builds target multiple different C++ versions (from C++03 to C++20), and this can be customized.
+To see what kind of coverage these builds provide, see some build results as follows or click the badges above:
 
-    AppVeyor : https://ci.appveyor.com/project/jeking3/uuid-gaamf/builds/19987101
-    Travis CI: https://travis-ci.org/boostorg/uuid/builds/449557162
+    AppVeyor : https://ci.appveyor.com/project/Flamefire/boost-ci/branch/master
+    Github Actions : https://github.com/boostorg/boost-ci/actions/workflows/ci.yml
+    Azure Pipelines : https://dev.azure.com/boostorg/boost-ci/_build/latest?definitionId=8&branchName=master
+    Travis CI : https://travis-ci.org/boostorg/uuid/builds/449557162
 
-Without any customization the scripts can provide the following services (example, see the actual CI scripts for current configurations):
+Without any customization the scripts can provide the following services (example only, see the actual CI scripts for current configurations):
 
 | CI        | description             | toolset     | cxxflags/std                  | address-model | variant         |
 | :-------- | :---------------------- | :---------- | :---------------------------- | :------------ | :-------------- |

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Build jobs that will severely impact performance (such as `valgrind`) will defin
 
 ## Topic Branch Support ##
 
-The configuration for Travis CI and Appveyor allow for automated branch builds on branch pushes matching these names:
+The configuration for Travis CI, Github Actions, Azure Pipelines and Appveyor allow for automated branch builds on branch pushes matching these names:
 
 - master
 - develop


### PR DESCRIPTION
After the discussion in https://github.com/boostorg/boost-ci/pull/135 I felt like a docu update was in need, especially regarding the pitfall that the `.codecov.yml` file needs to be in the **default** branch, not the current or target branch to be picked up.

So I looked over most of the Readme and enhanced/corrected parts of it and added a section about coverage data.

I also included Github Actions in the "to configure" part for coverity after #128 and mentioned big endian support after #130

@jeking3 Feel free to add anything you find important or provide suggestions for better wordings. I don't really have much time right now, but think at least these changes are important for other library authors to know.