### PR TITLE
Allow alternate bootstrap toolset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,7 @@ jobs:
       - name: Setup Boost
         env:
           B2_ADDRESS_MODEL: ${{matrix.address-model}}
+          B2_BOOTSTRAP_TOOLSET: ${{matrix.bootstrap-toolset}}
           B2_COMPILER: ${{matrix.compiler}}
           B2_CXXSTD: ${{matrix.cxxstd}}
           B2_SANITIZE: ${{matrix.sanitize}}
@@ -237,7 +238,7 @@ jobs:
           - { toolset: msvc-14.1, cxxstd: '14,17,latest',   addrmd: '32,64', os: windows-2016 }
           - { toolset: msvc-14.2, cxxstd: '14,17,20',       addrmd: '32,64', os: windows-2019 }
           - { toolset: msvc-14.3, cxxstd: '14,17,20',       addrmd: '32,64', os: windows-2022 }
-          - { toolset: gcc,       cxxstd: '03,11,14,17,2a', addrmd: '64',    os: windows-2019 }
+          - { toolset: gcc,       cxxstd: '03,11,14,17,2a', addrmd: '64',    os: windows-2022, bootstrap-toolset: mingw }
 
     runs-on: ${{matrix.os}}
 
@@ -258,6 +259,8 @@ jobs:
 
       - name: Setup Boost
         run: ci\github\install.bat
+        env:
+          B2_BOOTSTRAP_TOOLSET: ${{ matrix.bootstrap-toolset }}
 
       - name: Run tests
         run: ci\build.bat

--- a/ci/common_install.bat
+++ b/ci/common_install.bat
@@ -5,7 +5,8 @@ REM - BOOST_CI_TARGET_BRANCH
 REM - BOOST_CI_SRC_FOLDER
 REM
 REM Optional environment variables:
-REM - B2_BOOTSTRAP_TOOLSET (in some cases bootstrap.bat uses different toolset names)
+REM - B2_BOOTSTRAP_TOOLSET - Toolset to be used by bootstrap. If unset one is automatically chosen.
+REM -         Can be different than the toolset used for tests and must e.g. support C++11.
 REM
 
 @ECHO ON

--- a/ci/common_install.bat
+++ b/ci/common_install.bat
@@ -1,7 +1,12 @@
 REM Generic install script for Windows
+REM
 REM The following CI specific environment variables need to be set:
 REM - BOOST_CI_TARGET_BRANCH
 REM - BOOST_CI_SRC_FOLDER
+REM
+REM Optional environment variables:
+REM - B2_BOOTSTRAP_TOOLSET (in some cases bootstrap.bat uses different toolset names)
+REM
 
 @ECHO ON
 
@@ -52,7 +57,7 @@ if NOT %cxx_exe% == "" (
 
 REM Bootstrap is not expecting B2_CXXFLAGS content so we zero it out for the bootstrap only
 SET B2_CXXFLAGS=
-cmd /c bootstrap
+cmd /c bootstrap %B2_BOOTSTRAP_TOOLSET%
 IF NOT %ERRORLEVEL% == 0 (
     type bootstrap.log
     EXIT /B 1

--- a/ci/common_install.sh
+++ b/ci/common_install.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-# Copyright 2017 - 2019 James E. King III
+# Copyright 2017 - 2022 James E. King III
 # Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
 # Copyright 2020 Alexander Grund
 # Distributed under the Boost Software License, Version 1.0.
@@ -18,6 +18,9 @@
 # - BOOST_CI_TARGET_BRANCH
 # - BOOST_CI_SRC_FOLDER
 # - GIT_FETCH_JOBS to fetch in parallel
+#
+# Optional environment variables:
+# - B2_BOOTSTRAP_TOOLSET (in some cases bootstrap.sh uses different toolset names)
 #
 # Will set:
 # - BOOST_BRANCH
@@ -147,7 +150,7 @@ function show_bootstrap_log
 
 if [[ "$B2_DONT_BOOTSTRAP" != "1" ]]; then
     trap show_bootstrap_log ERR
-    ${B2_WRAPPER} ./bootstrap.sh
+    ${B2_WRAPPER} ./bootstrap.sh ${B2_BOOTSTRAP_TOOLSET:+--with-toolset=$B2_BOOTSTRAP_TOOLSET}
     trap - ERR
     ${B2_WRAPPER} ./b2 headers
 fi

--- a/ci/common_install.sh
+++ b/ci/common_install.sh
@@ -20,7 +20,8 @@
 # - GIT_FETCH_JOBS to fetch in parallel
 #
 # Optional environment variables:
-# - B2_BOOTSTRAP_TOOLSET (in some cases bootstrap.sh uses different toolset names)
+# - B2_BOOTSTRAP_TOOLSET - Toolset to be used by bootstrap. If unset, one is automatically chosen.
+#      Can be different than the toolset used for tests and must e.g. support C++11.
 #
 # Will set:
 # - BOOST_BRANCH


### PR DESCRIPTION
* The bootstrap for the windows gcc task was using msvc [see: Setup Boost step](https://github.com/boostorg/boost-ci/runs/5071617982?check_suite_focus=true)
* Added `B2_BOOTSTRAP_TOOLSET` to allow expressing an alternate toolset for building boost build.

This closes #138 