### PR TITLE
Ability to disable ppa:ubuntu-toolchain-r/test in drone

### DIFF
--- a/ci/drone/linux-cxx-install.sh
+++ b/ci/drone/linux-cxx-install.sh
@@ -2,7 +2,11 @@
 
 set -ex
 echo ">>>>> APT: REPO.."
-for i in {1..3}; do sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test" && break || sleep 10; done
+if [ "$UBUNTU_TOOLCHAIN_DISABLE" != "true" ]; then
+    for i in {1..3}; do sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test" && break || sleep 10; done
+else
+    echo "UBUNTU_TOOLCHAIN_DISABLE is 'true'. Not installing ppa:ubuntu-toolchain-r/test"
+fi
 
 if test -n "${LLVM_OS}" ; then
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -


### PR DESCRIPTION
@pdimov, per request, you could prevent the installation of ppa:ubuntu-toolchain-r/test by setting a global or per-job environment variable in .drone.star:

```
globalenv={'UBUNTU_TOOLCHAIN_DISABLE': 'true'}
```