### PR TITLE
gha: windows coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,8 @@ jobs:
       matrix:
         include:
           - { toolset: msvc-14.2, cxxstd: '14,17,20',       addrmd: '32,64', os: windows-2019 }
-          - { toolset: msvc-14.3, cxxstd: '14,17,20',       addrmd: '32,64', os: windows-2022 }
+          - { name: Collect coverage, coverage: yes,
+              toolset: msvc-14.3, cxxstd: '14,17,20',       addrmd: '32,64', os: windows-2022 }
           - { toolset: gcc,       cxxstd: '03,11,14,17,2a', addrmd: '64',    os: windows-2019 }
 
     runs-on: ${{matrix.os}}
@@ -259,11 +260,27 @@ jobs:
         run: ci\github\install.bat
 
       - name: Run tests
+        if: '!matrix.coverage'
         run: ci\build.bat
         env:
           B2_TOOLSET: ${{matrix.toolset}}
           B2_CXXSTD: ${{matrix.cxxstd}}
           B2_ADDRESS_MODEL: ${{matrix.addrmd}}
+
+      - name: Run coverage
+        shell: powershell
+        if: matrix.coverage
+        run: ci\opencppcoverage.ps1
+        env:
+          B2_TOOLSET: ${{matrix.toolset}}
+          B2_CXXSTD: ${{matrix.cxxstd}}
+          B2_ADDRESS_MODEL: ${{matrix.addrmd}}
+
+      - name: Upload coverage
+        if: matrix.coverage
+        uses: codecov/codecov-action@v2
+        with:
+          files: __out/cobertura.xml
 
   CMake:
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
           B2_CXXSTD: ${{matrix.cxxstd}}
           B2_ADDRESS_MODEL: ${{matrix.addrmd}}
 
-      - name: Run coverage
+      - name: Collect coverage
         shell: powershell
         if: matrix.coverage
         run: ci\opencppcoverage.ps1

--- a/ci/codecov.ps1
+++ b/ci/codecov.ps1
@@ -6,10 +6,6 @@ $ErrorActionPreference = "Stop"
 
 $scriptPath = split-path $MyInvocation.MyCommand.Path
 
-# Install coverage collector (Similar to LCov)
-choco install opencppcoverage
-$env:Path += ";C:\Program Files\OpenCppCoverage"
-
 # Install uploader
 Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
 
@@ -31,36 +27,8 @@ if (Get-Command "gpg.exe" -ErrorAction SilentlyContinue){
         exit 1
     }
 }
-    
-# Run build with coverage collection
-$env:B2_VARIANT = "debug"
 
-# Use a temporary folder to avoid codecov picking up wrong files
-mkdir __out
-
-# Build command to collect coverage
-$cmd = 'OpenCppCoverage.exe --export_type cobertura:__out/cobertura.xml --modules "{0}" ' -f ${env:BOOST_ROOT}
-# Include own headers (relocated to boost\*)
-$cmd += (Get-ChildItem -Name "${env:BOOST_CI_SRC_FOLDER}\include\boost").ForEach({'--sources "boost\{0}"' -f $_}) -join " "
-# Include own cpp files
-$cmd += " --sources ${env:BOOST_ROOT}\libs\${env:SELF} "
-$exclusions = @(
-  # Lines marked with LCov or coverity exclusion comments
-  '.*// LCOV_EXCL_LINE'
-  '.*// coverity\[dead_error_line\]'
-  # Lines containing only braces
-  '\s*[}{]*\s*'
-  # Lines containing only else (and opt. braces)
-  '\s*(\} )?else( \{)?\s*'
-)
-$cmd += $exclusions.ForEach({"--excluded_line_regex '{0}'" -f $_}) -join " "
-# Cover all subprocess of the build script (-> b2 -> test binary)
-$cmd += "--cover_children -- cmd.exe /c $scriptPath/build.bat"
-
-# Print generated command and run
-$cmd
-Invoke-Expression $cmd
-
+&"$scriptPath\opencppcoverage.ps1"
 if ($LASTEXITCODE -ne 0) { Throw "Coverage collection failed." }
 
 # Workaround for https://github.com/codecov/uploader/issues/525

--- a/ci/opencppcoverage.ps1
+++ b/ci/opencppcoverage.ps1
@@ -1,0 +1,38 @@
+# Copyright 2019 - 2021 Alexander Grund
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt)
+
+$scriptPath = split-path $MyInvocation.MyCommand.Path
+
+# Install coverage collector (Similar to LCov)
+choco install opencppcoverage
+$env:Path += ";C:\Program Files\OpenCppCoverage"
+
+# Run build with coverage collection
+$env:B2_VARIANT = "debug"
+
+# Use a temporary folder to avoid codecov picking up wrong files
+mkdir __out
+
+# Build command to collect coverage
+$cmd = 'OpenCppCoverage.exe --export_type cobertura:__out/cobertura.xml --modules "{0}" ' -f ${env:BOOST_ROOT}
+# Include own headers (relocated to boost\*)
+$cmd += (Get-ChildItem -Name "${env:BOOST_CI_SRC_FOLDER}\include\boost").ForEach({'--sources "boost\{0}"' -f $_}) -join " "
+# Include own cpp files
+$cmd += " --sources ${env:BOOST_ROOT}\libs\${env:SELF} "
+$exclusions = @(
+  # Lines marked with LCov or coverity exclusion comments
+  '.*// LCOV_EXCL_LINE'
+  '.*// coverity\[dead_error_line\]'
+  # Lines containing only braces
+  '\s*[}{]*\s*'
+  # Lines containing only else (and opt. braces)
+  '\s*(\} )?else( \{)?\s*'
+)
+$cmd += $exclusions.ForEach({"--excluded_line_regex '{0}'" -f $_}) -join " "
+# Cover all subprocess of the build script (-> b2 -> test binary)
+$cmd += "--cover_children -- cmd.exe /c $scriptPath\build.bat"
+
+# Print generated command and run
+$cmd
+Invoke-Expression $cmd


### PR DESCRIPTION
Separated the OpenCppCoverage out from shell invoked Covecov and switched to the codecov action to avoid download timeouts.