### PR TITLE
Add cygwin pthread threading definition to appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -96,6 +96,7 @@ environment:
       ADDPATH: C:\cygwin\bin;
       B2_ADDRESS_MODEL: 32
       B2_CXXSTD: 03,11,14,1z
+      B2_THREADING: threadapi=pthread
       B2_TOOLSET: gcc
 
     - FLAVOR: cygwin (64-bit)
@@ -103,6 +104,7 @@ environment:
       ADDPATH: C:\cygwin64\bin;
       B2_ADDRESS_MODEL: 64
       B2_CXXSTD: 03,11,14,1z
+      B2_THREADING: threadapi=pthread
       B2_TOOLSET: gcc
 
     - FLAVOR: mingw32


### PR DESCRIPTION
This is a definition I have been using in the uuid, format, and date_time appveyor scripts for cygwin builds.