### PR TITLE
add ubsan option report_error_type for easier building of ignorelists

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -14,7 +14,7 @@ set -ex
 
 . "$(dirname "${BASH_SOURCE[0]}")"/enforce.sh
 
-export UBSAN_OPTIONS=print_stacktrace=1
+export UBSAN_OPTIONS=print_stacktrace=1,report_error_type=1
 
 cd "$BOOST_ROOT"
 


### PR DESCRIPTION
This option prints out the sanitizer type on ubsan errors so you can more easily figure out how to make an ignorelist entry (though it's still not "easy"...)