### PR TITLE
Add CI job using a newer Cygwin

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -105,6 +105,15 @@ environment:
       B2_CXXSTD: 03,11,14,1z
       B2_TOOLSET: gcc
 
+    # (Currently) the images up to 2017 use an older Cygwin
+    # This tests that the library works with more recent versions
+    - FLAVOR: cygwin (64-bit, latest)
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      ADDPATH: C:\cygwin64\bin;
+      B2_ADDRESS_MODEL: 64
+      B2_CXXSTD: 03,11,14,1z
+      B2_TOOLSET: gcc
+
     - FLAVOR: mingw32
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       B2_ADDRESS_MODEL: 32

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -8,6 +8,11 @@
 import os ;
 import testing ;
 
+project boost/ci/test
+    : requirements
+      <include>.
+    ;
+
 local B2_ADDRESS_MODEL = [ os.environ B2_ADDRESS_MODEL ] ;
 local B2_CXXFLAGS = [ os.environ B2_CXXFLAGS ] ;
 local B2_CXXSTD = [ os.environ B2_CXXSTD ] ;


### PR DESCRIPTION
The Appveyor images 2015&2017 use Cygwin 3.0.7 while the newer 2019&2022 images use 3.1.7.
Hence add an additional Cygwin test using the "Visual Studio 2022" appveyor image.

Motivated by failing tests due to relative includes which are not possible by default on recent Cygwin. See e.g. https://github.com/boostorg/atomic/issues/56