### PR TITLE
test linkflags

### DIFF
--- a/.github/workflows/old_ci.yml
+++ b/.github/workflows/old_ci.yml
@@ -38,9 +38,21 @@ jobs:
               B2_VARIANT: variant=release
               # Possible (ab)usage
               B2_CXXFLAGS: define=norecover
-
               B2_DEFINES: define=BOOST_NO_STRESS_TEST=1
               B2_LINKFLAGS: linkflags=-fuse-ld=gold
+            os: ubuntu-20.04
+            install: g++-8
+          - name: Old var usage, multiple LINKFLAGS
+            env:
+              B2_TOOLSET: gcc-8
+              B2_ADDRESS_MODEL: address-model=64
+              B2_LINK: link=shared,static
+              B2_THREADING: threading=multi,single
+              B2_VARIANT: variant=release
+              # Possible (ab)usage
+              B2_CXXFLAGS: define=norecover
+              B2_DEFINES: define=BOOST_NO_STRESS_TEST=1
+              B2_LINKFLAGS: linkflags=-fsanitize=undefined linkflags=-fno-sanitize-recover=all linkflags=-fuse-ld=gold
             os: ubuntu-20.04
             install: g++-8
           - name: Travis-like coverage collection

--- a/.github/workflows/old_ci.yml
+++ b/.github/workflows/old_ci.yml
@@ -42,7 +42,7 @@ jobs:
               B2_LINKFLAGS: linkflags=-fuse-ld=gold
             os: ubuntu-20.04
             install: g++-8
-          - name: Old var usage, multiple LINKFLAGS
+          - name: Old var usage, multiple values per key
             env:
               B2_TOOLSET: gcc-8
               B2_ADDRESS_MODEL: address-model=64
@@ -51,7 +51,7 @@ jobs:
               B2_VARIANT: variant=release
               # Possible (ab)usage
               B2_CXXFLAGS: define=norecover
-              B2_DEFINES: define=BOOST_NO_STRESS_TEST=1
+              B2_DEFINES: define=BOOST_NO_STRESS_TEST=1 define=BOOST_IMPORTANT=1
               B2_LINKFLAGS: linkflags=-fsanitize=undefined linkflags=-fno-sanitize-recover=all linkflags=-fuse-ld=gold
             os: ubuntu-20.04
             install: g++-8

--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -28,13 +28,16 @@ set -ex
 . $(dirname "${BASH_SOURCE[0]}")/enforce.sh
 
 if [[ "$1" == "setup" ]]; then
-    export B2_VARIANT=debug
     if [ -z "$B2_CI_VERSION" ]; then
+        # Old CI version needs to use the prefixes
+        export B2_VARIANT="variant=debug"
         export B2_CXXFLAGS="${B2_CXXFLAGS:+$B2_CXXFLAGS }cxxflags=-fkeep-static-functions cxxflags=--coverage"
+        export B2_LINKFLAGS="${B2_LINKFLAGS:+$B2_LINKFLAGS } linkflags=--coverage"
     else
+        export B2_VARIANT=debug
         export B2_CXXFLAGS="${B2_CXXFLAGS:+$B2_CXXFLAGS }-fkeep-static-functions --coverage"
+        export B2_LINKFLAGS="${B2_LINKFLAGS:+$B2_LINKFLAGS }--coverage"
     fi
-    export B2_LINKFLAGS="${B2_LINKFLAGS:+$B2_LINKFLAGS }--coverage"
 
 elif [[ "$1" == "upload" ]]; then
     if [ -z "$GCOV" ]; then

--- a/ci/enforce.sh
+++ b/ci/enforce.sh
@@ -52,41 +52,42 @@ if [ -z "${B2_JOBS}" ]; then
     export B2_JOBS=$((cpus + 1))
 fi
 
-# For old versions strip prefix from variables
-if [ -z "$B2_CI_VERSION" ]; then
-    # Skipped:
-    # B2_THREADING: can be threading= or threadapi=
-    B2_DEFINES="${B2_DEFINES#define=}"
-    B2_INCLUDE="${B2_INCLUDE#include=}"
-    B2_LINKFLAGS="${B2_LINKFLAGS#linkflags=}"
-    B2_ADDRESS_MODEL="${B2_ADDRESS_MODEL#address-model=}"
-    B2_LINK="${B2_LINK#link=}"
-    B2_VARIANT="${B2_VARIANT#variant=}"
-    if [ -n "$B2_CXXFLAGS" ]; then
-        # Sometimes (ab)used for sanitizers, so play safe and add it to B2_FLAGS
-        B2_FLAGS="$B2_FLAGS $B2_CXXFLAGS"
-        unset B2_CXXFLAGS
-    fi
-fi
-
 # Build cmdline arguments for B2 as an array to preserve quotes
-B2_ARGS=(
-    ${B2_TOOLSET:+"toolset=$B2_TOOLSET"}
-    "cxxstd=$B2_CXXSTD"
-    ${B2_CXXFLAGS:+"cxxflags=$B2_CXXFLAGS"}
-    ${B2_DEFINES:+"define=$B2_DEFINES"}
-    ${B2_INCLUDE:+"include=$B2_INCLUDE"}
-    ${B2_LINKFLAGS:+"linkflags=$B2_LINKFLAGS"}
-    ${B2_TESTFLAGS}
-    ${B2_ADDRESS_MODEL:+address-model=$B2_ADDRESS_MODEL}
-    ${B2_LINK:+link=$B2_LINK}
-    ${B2_VISIBILITY:+visibility=$B2_VISIBILITY}
-    ${B2_STDLIB:+"stdlib=$B2_STDLIB"}
-    ${B2_THREADING}
-    ${B2_VARIANT:+variant=$B2_VARIANT}
-    ${B2_ASAN:+address-sanitizer=norecover}
-    ${B2_TSAN:+thread-sanitizer=norecover}
-    ${B2_UBSAN:+undefined-sanitizer=norecover}
-    -j${B2_JOBS}
-    ${B2_FLAGS}
-)
+if [ -z "$B2_CI_VERSION" ]; then
+  # For old versions the prefix was included in (most) variables
+  B2_ARGS=(
+      toolset=$B2_TOOLSET
+      cxxstd=$B2_CXXSTD
+      $B2_CXXFLAGS
+      $B2_DEFINES
+      $B2_INCLUDE
+      $B2_LINKFLAGS
+      $B2_TESTFLAGS
+      $B2_ADDRESS_MODEL
+      $B2_LINK
+      $B2_THREADING
+      $B2_VARIANT
+      -j${B2_JOBS}
+  )
+else
+  B2_ARGS=(
+      ${B2_TOOLSET:+"toolset=$B2_TOOLSET"}
+      "cxxstd=$B2_CXXSTD"
+      ${B2_CXXFLAGS:+"cxxflags=$B2_CXXFLAGS"}
+      ${B2_DEFINES:+"define=$B2_DEFINES"}
+      ${B2_INCLUDE:+"include=$B2_INCLUDE"}
+      ${B2_LINKFLAGS:+"linkflags=$B2_LINKFLAGS"}
+      ${B2_TESTFLAGS}
+      ${B2_ADDRESS_MODEL:+address-model=$B2_ADDRESS_MODEL}
+      ${B2_LINK:+link=$B2_LINK}
+      ${B2_VISIBILITY:+visibility=$B2_VISIBILITY}
+      ${B2_STDLIB:+"stdlib=$B2_STDLIB"}
+      ${B2_THREADING}
+      ${B2_VARIANT:+variant=$B2_VARIANT}
+      ${B2_ASAN:+address-sanitizer=norecover}
+      ${B2_TSAN:+thread-sanitizer=norecover}
+      ${B2_UBSAN:+undefined-sanitizer=norecover}
+      -j${B2_JOBS}
+      ${B2_FLAGS}
+  )
+fi


### PR DESCRIPTION
A number of boost libraries have set B2_LINKFLAGS in their CI tests. Here is an example from signals2 https://github.com/boostorg/signals2/blob/develop/.travis.yml

- B2_LINKFLAGS="linkflags=-fsanitize=undefined linkflags=-fno-sanitize-recover=all linkflags=-fuse-ld=gold"

That configuration used to work fine in Drone and GHA.   Now an error is appearing:  

```
g++-8: error: linkflags=-fno-sanitize-recover=all: No such file or directory
g++-8: error: linkflags=-fuse-ld=gold: No such file or directory
```

Is the syntax wrong? Any ideas?

The issue might be connected to the following commit, or possibly a different one which modified b2_linkflags.

```
85baccf9 (Alexander Grund   2021-11-10 23:07:31 +0100 79)     ${B2_LINKFLAGS:+"linkflags=$B2_LINKFLAGS"}
```

A suggestion would be that in both "old ci.yml" and "new ci.yml", we include - 

- a test that has a linkflag and a cxxflag
- a test that has two (or more) linkflags and also two (or more) cxxflags

