### PR TITLE
GHA: Persist all env variables supported in B2_ARGS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,10 @@ jobs:
           B2_CXXSTD: ${{matrix.cxxstd}}
           B2_SANITIZE: ${{matrix.sanitize}}
           B2_STDLIB: ${{matrix.stdlib}}
+          # More entries can be added in the same way, see the B2_ARGS assignment in ci/enforce.sh for the possible keys.
+          # B2_DEFINES: ${{matrix.defines}}
+          # Variables set here (to non-empty) will override the top-level environment variables, e.g.
+          # B2_VARIANT: ${{matrix.variant}}
         run: source ci/github/install.sh
 
       - name: Setup coverage collection

--- a/ci/github/install.sh
+++ b/ci/github/install.sh
@@ -20,22 +20,40 @@ export BOOST_CI_SRC_FOLDER="${GITHUB_WORKSPACE//\\//}"
 echo "BOOST_CI_TARGET_BRANCH=$BOOST_CI_TARGET_BRANCH" >> $GITHUB_ENV
 echo "BOOST_CI_SRC_FOLDER=$BOOST_CI_SRC_FOLDER" >> $GITHUB_ENV
 
-[ -z "$B2_ADDRESS_MODEL"] || echo "B2_ADDRESS_MODEL=$B2_ADDRESS_MODEL" >> $GITHUB_ENV
-echo "B2_CXXSTD=$B2_CXXSTD" >> $GITHUB_ENV
 if [[ "$B2_SANITIZE" == "yes" ]]; then
-  echo "B2_ASAN=1" >> $GITHUB_ENV
-  echo "B2_UBSAN=1" >> $GITHUB_ENV
+  B2_ASAN=1
+  B2_UBSAN=1
   if [[ -f $BOOST_CI_SRC_FOLDER/ubsan-blacklist ]]; then
-    echo "B2_CXXFLAGS=${B2_CXXFLAGS:+$B2_CXXFLAGS }-fsanitize-blacklist=libs/$SELF/ubsan-blacklist" >> $GITHUB_ENV
+    B2_CXXFLAGS="${B2_CXXFLAGS:+$B2_CXXFLAGS }-fsanitize-blacklist=libs/$SELF/ubsan-blacklist"
   fi
   if [[ -f $BOOST_CI_SRC_FOLDER/.ubsan-ignorelist ]]; then
-    echo "B2_CXXFLAGS=${B2_CXXFLAGS:+$B2_CXXFLAGS }-fsanitize-blacklist=libs/$SELF/.ubsan-ignorelist" >> $GITHUB_ENV
+    B2_CXXFLAGS="${B2_CXXFLAGS:+$B2_CXXFLAGS }-fsanitize-blacklist=libs/$SELF/.ubsan-ignorelist"
   fi
 fi
 
 . $(dirname "${BASH_SOURCE[0]}")/../common_install.sh
+
+# Persist the environment for all future steps
+
+# Set by common_install.sh
 echo "SELF=$SELF" >> $GITHUB_ENV
 echo "BOOST_ROOT=$BOOST_ROOT" >> $GITHUB_ENV
 echo "B2_TOOLSET=$B2_TOOLSET" >> $GITHUB_ENV
 echo "B2_COMPILER=$B2_COMPILER" >> $GITHUB_ENV
+# Usually set by the env-key of the "Setup Boost" step
+[ -z "$B2_CXXSTD" ] || echo "B2_CXXSTD=$B2_CXXSTD" >> $GITHUB_ENV
+[ -z "$B2_CXXFLAGS" ] || echo "B2_CXXFLAGS=$B2_CXXFLAGS" >> $GITHUB_ENV
+[ -z "$B2_DEFINES" ] || echo "B2_DEFINES=$B2_DEFINES" >> $GITHUB_ENV
+[ -z "$B2_INCLUDE" ] || echo "B2_INCLUDE=$B2_INCLUDE" >> $GITHUB_ENV
+[ -z "$B2_LINKFLAGS" ] || echo "B2_LINKFLAGS=$B2_LINKFLAGS" >> $GITHUB_ENV
+[ -z "$B2_TESTFLAGS" ] || echo "B2_TESTFLAGS=$B2_TESTFLAGS" >> $GITHUB_ENV
+[ -z "$B2_ADDRESS_MODEL" ] || echo "B2_ADDRESS_MODEL=$B2_ADDRESS_MODEL" >> $GITHUB_ENV
+[ -z "$B2_LINK" ] || echo "B2_LINK=$B2_LINK" >> $GITHUB_ENV
+[ -z "$B2_VISIBILITY" ] || echo "B2_VISIBILITY=$B2_VISIBILITY" >> $GITHUB_ENV
 [ -z "$B2_STDLIB" ] || echo "B2_STDLIB=$B2_STDLIB" >> $GITHUB_ENV
+[ -z "$B2_THREADING" ] || echo "B2_THREADING=$B2_THREADING" >> $GITHUB_ENV
+[ -z "$B2_VARIANT" ] || echo "B2_VARIANT=$B2_VARIANT" >> $GITHUB_ENV
+[ -z "$B2_ASAN" ] || echo "B2_ASAN=$B2_ASAN" >> $GITHUB_ENV
+[ -z "$B2_TSAN" ] || echo "B2_TSAN=$B2_TSAN" >> $GITHUB_ENV
+[ -z "$B2_UBSAN" ] || echo "B2_UBSAN=$B2_UBSAN" >> $GITHUB_ENV
+[ -z "$B2_FLAGS" ] || echo "B2_FLAGS=$B2_FLAGS" >> $GITHUB_ENV


### PR DESCRIPTION
This allows library maintainers to pass additional env-keys to the "Setup Boost" step.

Order matches the one in enforce.sh, so some stuff needed to be moved around. But this allows easier verification we save all keys.

@sdarwin As you suggested in #150 
> A suggestion would be that in both "old ci.yml" and "new ci.yml", we include -
>
>    a test that has a linkflag and a cxxflag
>    a test that has two (or more) linkflags and also two (or more) cxxflags

I noticed that we currently don't need `linkflag` on GHA and hence don't support it in the "Setup Boost" step. This adds that missing support.

Note that only non-empty variables are stored. This could be a limitation for the following use case:
- Default value set in global config, see e.g. https://github.com/boostorg/boost-ci/blob/ef736dcb9df80a5e3707cf4228ed41a7341cc42b/.github/workflows/ci.yml#L30
- Then it is set to empty e.g. by a matrix-entry in the setup step at https://github.com/boostorg/boost-ci/blob/ef736dcb9df80a5e3707cf4228ed41a7341cc42b/.github/workflows/ci.yml#L202-L208

This use case is currently not supported. Should we?