### PR TITLE
Add install-test option to cmake_test sub-test

### DIFF
--- a/test/cmake_test/CMakeLists.txt
+++ b/test/cmake_test/CMakeLists.txt
@@ -8,6 +8,7 @@ project(cmake_subdir_test LANGUAGES CXX)
 
 # Those 2 should work the same
 # while using find_package for the installed Boost avoids the need to manually specify dependencies
+option(BOOST_CI_INSTALL_TEST "Try to use an installed Boost" OFF)
 if(BOOST_CI_INSTALL_TEST)
     find_package(boost_boost_ci REQUIRED)
 else()


### PR DESCRIPTION
Add an `option` for `BOOST_CI_INSTALL_TEST` as otherwise that variable may be undefined and yield unexpected results

I had that in Nowide where I added an `DEFINED` check, but the `option` is cleaner