### PR TITLE
fix mingw builds - pacman archive 5.2.1 was removed upstream

### DIFF
--- a/ci/appveyor/mingw.bat
+++ b/ci/appveyor/mingw.bat
@@ -40,7 +40,7 @@ echo     pacman --noconfirm -U msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz
 echo     echo "Packages:"
 echo     pacman --noconfirm -U "http://repo.msys2.org/msys/x86_64/libzstd-1.4.5-2-x86_64.pkg.tar.xz"
 echo     pacman --noconfirm -U "http://repo.msys2.org/msys/x86_64/zstd-1.4.5-2-x86_64.pkg.tar.xz"
-echo     pacman --noconfirm -U "http://repo.msys2.org/msys/x86_64/pacman-5.2.1-12-x86_64.pkg.tar.xz"
+echo     pacman --noconfirm -U "http://repo.msys2.org/msys/x86_64/pacman-5.2.2-5-x86_64.pkg.tar.xz"
 echo else
 echo     echo "Not upgrading pacman"
 echo fi


### PR DESCRIPTION
http://repo.msys2.org/msys/x86_64/pacman-5.2.1-12-x86_64.pkg.tar.xz was removed upstream