### PR TITLE
Add test (and fix) for shared libraries with dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,15 +7,21 @@ cmake_minimum_required(VERSION 3.5...3.16)
 
 project(boost_ci VERSION "${BOOST_SUPERPROJECT_VERSION}" LANGUAGES CXX)
 
-add_library(boost_boost_ci INTERFACE)
+add_library(boost_boost_ci src/boost_ci.cpp)
 add_library(Boost::boost_ci ALIAS boost_boost_ci)
 
-target_include_directories(boost_boost_ci INTERFACE include)
+target_include_directories(boost_boost_ci PUBLIC include)
 
 target_link_libraries(boost_boost_ci
-  INTERFACE
+  PUBLIC
     Boost::config
+  PRIVATE
+    Boost::atomic
 )
+
+if(BUILD_SHARED_LIBS)
+  target_compile_definitions(boost_boost_ci PUBLIC BOOST_BOOST_CI_DYN_LINK)
+endif()
 
 if(BUILD_TESTING)
   add_subdirectory(test)

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -1,0 +1,25 @@
+# Boost CI Test Build Jamfile
+
+# Copyright (c) 2022 Alexander Grund
+# 
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE or www.boost.org/LICENSE_1_0.txt)
+
+import configure ;
+
+local requirements =
+  <link>shared:<define>BOOST_BOOST_CI_DYN_LINK=1
+  <library>/boost/atomic//boost_atomic
+  ;
+
+project boost/ci
+  : source-location ../src
+  : requirements $(requirements)
+  : usage-requirements $(requirements)
+  ;
+
+lib boost_ci
+  : boost_ci.cpp
+  ;
+
+boost-install boost_ci ;

--- a/include/boost/boost-ci/boost_ci.hpp
+++ b/include/boost/boost-ci/boost_ci.hpp
@@ -11,6 +11,17 @@
 #include <memory>
 #endif
 
+// This define is usually set in boost/<libname>/config.hpp
+#if defined(BOOST_ALL_DYN_LINK) || defined(BOOST_BOOST_CI_DYN_LINK)
+#ifdef BOOST_BOOST_CI_SOURCE
+#define BOOST_BOOST_CI_DECL BOOST_SYMBOL_EXPORT
+#else
+#define BOOST_BOOST_CI_DECL BOOST_SYMBOL_IMPORT
+#endif
+#else
+#define BOOST_BOOST_CI_DECL
+#endif
+
 namespace boost
 {
   namespace boost_ci
@@ -21,25 +32,7 @@ namespace boost
 #define MSVC_VALUE false
 #endif
 
-    // Some function to test
-    BOOST_NOINLINE int get_answer(const bool isMsvc = MSVC_VALUE)
-    {
-      int answer;
-      // Specifically crafted condition to check for coverage from MSVC and non MSVC builds
-      if(isMsvc)
-      {
-        answer = 21;
-      } else
-      {
-        answer = 42;
-      }
-#ifdef BOOST_NO_CXX11_SMART_PTR
-      return answer;
-#else
-      // Just use some stdlib feature combined with a Boost.Config feature as demonstration
-      auto ptr = std::unique_ptr<int>(new int(answer));
-      return *ptr;
-#endif
-    }
+    // Some function to test. Returns 41 for true, 42 otherwise
+    BOOST_BOOST_CI_DECL int get_answer(bool isMsvc = MSVC_VALUE);
   }
 }

--- a/src/boost_ci.cpp
+++ b/src/boost_ci.cpp
@@ -1,0 +1,39 @@
+//
+// Copyright (c) 2022 Alexander Grund
+//
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_BOOST_CI_SOURCE
+
+#include <boost/boost-ci/boost_ci.hpp>
+// Just some dependency on another Boost library
+#include <boost/atomic/atomic.hpp>
+
+namespace boost
+{
+  namespace boost_ci
+  {
+    // Some function to test
+    int get_answer(const bool isMsvc)
+    {
+      boost::atomic_int answer;
+      // Specifically crafted condition to check for coverage from MSVC and non MSVC builds
+      if(isMsvc)
+      {
+        answer = 21;
+      } else
+      {
+        answer = 42;
+      }
+#ifdef BOOST_NO_CXX11_SMART_PTR
+      return answer;
+#else
+      // Just use some stdlib feature combined with a Boost.Config feature as demonstration
+      auto ptr = std::unique_ptr<int>(new int(answer));
+      return *ptr;
+#endif
+    }
+  }
+}

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -8,9 +8,8 @@
 import os ;
 import testing ;
 
-project boost/ci/test
-    : requirements
-      <include>.
+project : requirements
+      <library>/boost/ci//boost_ci
     ;
 
 local B2_ADDRESS_MODEL = [ os.environ B2_ADDRESS_MODEL ] ;

--- a/test/cmake_test/CMakeLists.txt
+++ b/test/cmake_test/CMakeLists.txt
@@ -11,8 +11,27 @@ project(cmake_subdir_test LANGUAGES CXX)
 if(BOOST_CI_INSTALL_TEST)
     find_package(boost_boost_ci REQUIRED)
 else()
-    add_subdirectory(../.. boostorg/ci)
-    add_subdirectory(../../../config boostorg/config)
+    add_subdirectory(../.. boostorg/boost-ci)
+
+    set(deps
+      # Primary dependencies
+      atomic
+      config
+      core
+      # Secondary dependencies
+      align
+      assert
+      predef
+      preprocessor
+      static_assert
+      throw_exception
+      type_traits
+      winapi
+    )
+
+    foreach(dep IN LISTS deps)
+      add_subdirectory(../../../${dep} boostorg/${dep})
+    endforeach()
 endif()
 
 add_executable(main main.cpp)


### PR DESCRIPTION
Convert the header-only library to a compiled library which additionally depends (privately) on another compiled library (Boost.Atomic chosen as it has few other dependencies).
This reproduces the runtime link failure of #155 when compiling shared libraries.