### PR TITLE
GHA: update actions/cache + actions/checkout to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,20 +124,20 @@ jobs:
             fi
             git config --global pack.threads 0
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # For coverage builds fetch the whole history, else only 1 commit using a 'fake ternary'
           fetch-depth: ${{ matrix.coverage && '0' || '1' }}
 
       - name: Cache ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         if: env.B2_USE_CCACHE
         with:
           path: ~/.ccache
           key: ${{matrix.os}}-${{matrix.container}}-${{matrix.compiler}}
 
       - name: Fetch Boost.CI
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: boostorg/boost-ci
           ref: master
@@ -247,10 +247,10 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Fetch Boost.CI
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: boostorg/boost-ci
           ref: master
@@ -301,7 +301,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup MSYS2 environment
         uses: msys2/setup-msys2@v2
@@ -312,7 +312,7 @@ jobs:
           pacboy: gcc:p cmake:p ninja:p
 
       - name: Fetch Boost.CI
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: boostorg/boost-ci
           ref: master
@@ -361,9 +361,9 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Fetch Boost.CI
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: boostorg/boost-ci
           ref: master


### PR DESCRIPTION
Updates the `actions/checkout` and ` actions/cache` actions used in the GitHub Actions workflow to their newest version.

Changes in [actions/cache](https://github.com/actions/cache):

> ### 3.0.0
> - Updated minimum runner version support from node 12 -> node 16
>
> ### 3.0.1
> - Added support for caching from GHES 3.5.
> - Fixed download issue for files > 2GB during restore.

Changes in [actions/checkout](https://github.com/actions/checkout):

> ## v3.0.2
> - [Add input `set-safe-directory`](https://github.com/actions/checkout/pull/770)
>
> ## v3.0.1
> - [Fixed an issue where checkout failed to run in container jobs due to the new git setting `safe.directory`](https://github.com/actions/checkout/pull/762)
> - [Bumped various npm package versions](https://github.com/actions/checkout/pull/744)
>
> ## v3.0.0
>
> - [Update to node 16](https://github.com/actions/checkout/pull/689)

As far as I can tell this should all be backwards compatible, so I do not expect any breakage.