### PR TITLE
Enable parallel CMake builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,7 +340,7 @@ jobs:
             cd "$BOOST_ROOT"
             mkdir __build_cmake_test__ && cd __build_cmake_test__
             cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBOOST_INCLUDE_LIBRARIES=$SELF -DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=ON -DBoost_VERBOSE=ON ..
-            cmake --build . --target tests --config Debug
+            cmake --build . --target tests --config Debug -j$B2_JOBS
             ctest --output-on-failure --build-config Debug
 
   CMake:
@@ -382,7 +382,7 @@ jobs:
             cd "$BOOST_ROOT"
             mkdir __build_cmake_test__ && cd __build_cmake_test__
             cmake -G "${{matrix.generator}}" -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBOOST_INCLUDE_LIBRARIES=$SELF -DBUILD_SHARED_LIBS=${{matrix.build_shared}} -DBUILD_TESTING=ON -DBoost_VERBOSE=ON ..
-            cmake --build . --target tests --config ${{matrix.build_type}}
+            cmake --build . --target tests --config ${{matrix.build_type}} -j$B2_JOBS
             ctest --output-on-failure --build-config ${{matrix.build_type}}
 
       - name: Run CMake subdir tests
@@ -392,7 +392,7 @@ jobs:
             cd "$cmake_test_folder"
             mkdir __build_cmake_subdir_test__ && cd __build_cmake_subdir_test__
             cmake -G "${{matrix.generator}}" -DBOOST_CI_INSTALL_TEST=OFF -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBUILD_SHARED_LIBS=${{matrix.build_shared}} ..
-            cmake --build . --config ${{matrix.build_type}}
+            cmake --build . --config ${{matrix.build_type}} -j$B2_JOBS
             ctest --output-on-failure --build-config ${{matrix.build_type}}
 
       - name: Install Library
@@ -400,7 +400,7 @@ jobs:
             cd "$BOOST_ROOT"
             mkdir __build_cmake_install_test__ && cd __build_cmake_install_test__
             cmake -G "${{matrix.generator}}" -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBOOST_INCLUDE_LIBRARIES=$SELF -DBUILD_SHARED_LIBS=${{matrix.build_shared}} -DCMAKE_INSTALL_PREFIX=~/.local -DBoost_VERBOSE=ON -DBoost_DEBUG=ON ..
-            cmake --build . --target install --config ${{matrix.build_type}}
+            cmake --build . --target install --config ${{matrix.build_type}} -j$B2_JOBS
       - name: Run CMake install tests
         run: |
             cmake_test_folder="$BOOST_ROOT/libs/$SELF/test/cmake_test" # New unified folder
@@ -408,5 +408,5 @@ jobs:
             cd "$cmake_test_folder"
             mkdir __build_cmake_install_test__ && cd __build_cmake_install_test__
             cmake -G "${{matrix.generator}}" -DBOOST_CI_INSTALL_TEST=ON -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBUILD_SHARED_LIBS=${{matrix.build_shared}} -DCMAKE_PREFIX_PATH=~/.local ..
-            cmake --build . --config ${{matrix.build_type}}
+            cmake --build . --config ${{matrix.build_type}} -j$B2_JOBS
             ctest --output-on-failure --build-config ${{matrix.build_type}}

--- a/ci/github/install.sh
+++ b/ci/github/install.sh
@@ -42,6 +42,7 @@ echo "B2_TOOLSET=$B2_TOOLSET" >> $GITHUB_ENV
 echo "B2_COMPILER=$B2_COMPILER" >> $GITHUB_ENV
 # Usually set by the env-key of the "Setup Boost" step
 [ -z "$B2_CXXSTD" ] || echo "B2_CXXSTD=$B2_CXXSTD" >> $GITHUB_ENV
+[ -z "$B2_JOBS" ] || echo "B2_JOBS=$B2_JOBS" >> $GITHUB_ENV
 [ -z "$B2_CXXFLAGS" ] || echo "B2_CXXFLAGS=$B2_CXXFLAGS" >> $GITHUB_ENV
 [ -z "$B2_DEFINES" ] || echo "B2_DEFINES=$B2_DEFINES" >> $GITHUB_ENV
 [ -z "$B2_INCLUDE" ] || echo "B2_INCLUDE=$B2_INCLUDE" >> $GITHUB_ENV


### PR DESCRIPTION
Use `B2_JOBS `to run the CMake build jobs in parallel to reduce CI time.