### PR TITLE
Workaround Clang 14 ASAN false positive on throwing exceptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           - { compiler: clang-6.0, cxxstd: '03,11,14',       os: ubuntu-18.04, stdlib: libc++, install: 'clang-6.0 libc++-dev libc++abi-dev' }
           - { compiler: clang-12,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04, stdlib: libc++, install: 'clang-12 libc++-12-dev libc++abi-12-dev' }
           - { name: Clang w/ sanitizers, sanitize: yes,
-              compiler: clang-14,  cxxstd: '03,11,14,17,20', os: ubuntu-22.04, stdlib: libc++, install: 'clang-14 libc++-14-dev libc++abi-14-dev' }
+              compiler: clang-13,  cxxstd: '03,11,14,17,20', os: ubuntu-22.04, stdlib: libc++, install: 'clang-13 libc++-13-dev libc++abi-13-dev' }
 
           # OSX, clang
           - { compiler: clang,     cxxstd: '03,11,14,17,2a', os: macos-10.15, sanitize: yes }

--- a/include/boost/boost-ci/boost_ci.hpp
+++ b/include/boost/boost-ci/boost_ci.hpp
@@ -7,32 +7,38 @@
 
 // Just something so we can test dependencies on other Boost libs
 #include <boost/config.hpp>
+#include <stdexcept>
 #ifndef BOOST_NO_CXX11_SMART_PTR
 #include <memory>
+#endif
+
+#ifdef BOOST_MSVC
+#define MSVC_VALUE 1
+#else
+#define MSVC_VALUE 0
 #endif
 
 namespace boost
 {
   namespace boost_ci
   {
-#ifdef BOOST_MSVC
-#define MSVC_VALUE true
-#else
-#define MSVC_VALUE false
-#endif
+    class BOOST_SYMBOL_VISIBLE example_error : public std::runtime_error {
+    public:
+      example_error() : std::runtime_error("Example error for demonstration") {}
+    };
 
     // Some function to test
-    BOOST_NOINLINE int get_answer(const bool isMsvc = MSVC_VALUE)
+    BOOST_NOINLINE int get_answer(const int isMsvc = MSVC_VALUE)
     {
       int answer;
       // Specifically crafted condition to check for coverage from MSVC and non MSVC builds
-      if(isMsvc)
-      {
-        answer = 21;
-      } else
-      {
+      if(isMsvc == 0)
         answer = 42;
-      }
+      else if(isMsvc == 1)
+        answer = 21;
+      else
+        throw example_error();
+
 #ifdef BOOST_NO_CXX11_SMART_PTR
       return answer;
 #else

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -31,5 +31,6 @@ int main()
       BOOST_TEST_EQ(boost::boost_ci::get_answer(), 42);
     }
     BOOST_TEST_EQ(map["result"].size(), 1u);
+    BOOST_TEST_THROWS(boost::boost_ci::get_answer(-1), boost::boost_ci::example_error);
     return boost::report_errors();
 }


### PR DESCRIPTION
Fix the `AddressSanitizer: alloc-dealloc-mismatch (operator new vs free)` false positive reported by recent Clang with libc++ by reverting to Clang 13.
Fixes https://github.com/boostorg/boost-ci/issues/167

Contains a reproducer for the issue.

Draft until CI for the reproducer confirms the false positive and this the fix.