### PR TITLE
Add msvc-14.0 and clang-win to GHA Windows jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,9 +243,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - { toolset: msvc-14.0, cxxstd: '14,latest',      addrmd: '32,64', os: windows-2019 }
           - { toolset: msvc-14.2, cxxstd: '14,17,20',       addrmd: '32,64', os: windows-2019 }
           - { name: Collect coverage, coverage: yes,
               toolset: msvc-14.3, cxxstd: '14,17,20',       addrmd: '32,64', os: windows-2022 }
+          - { toolset: clang-win, cxxstd: '14,17,latest',   addrmd: '32,64', os: windows-2022 }
           - { toolset: gcc,       cxxstd: '03,11,14,17,2a', addrmd: '64',    os: windows-2019 }
 
     runs-on: ${{matrix.os}}

--- a/ci/build.bat
+++ b/ci/build.bat
@@ -21,6 +21,12 @@ set SELF_S=%SELF:\=/%
 IF NOT DEFINED B2_TARGETS (SET B2_TARGETS=libs/!SELF_S!/test)
 IF NOT DEFINED B2_JOBS (SET B2_JOBS=3)
 
+REM clang-win requires to use the linker for the manifest on Github Actions
+IF DEFINED GITHUB_ACTIONS IF "%B2_TOOLSET%" == "clang-win" (
+    IF NOT DEFINED B2_FLAGS (SET B2_FLAGS=embed-manifest-via=linker)
+    ELSE (SET B2_FLAGS=embed-manifest-via=linker %B2_FLAGS%)
+)
+
 cd %BOOST_ROOT%
 
 IF DEFINED SCRIPT (


### PR DESCRIPTION
The clang-win job requires `embed-manifest-via=linker`

See run at https://github.com/boostorg/boost-ci/runs/6789632405?check_suite_focus=true    
and upstream issue https://github.com/bfgroup/b2/issues/159

@pdimov We had that in Boost.Unordered. I think it makes sense to put that here instead of unconditionally add it everywhere.

Note that the Appveyor clang-win job works without this flag: https://ci.appveyor.com/project/Flamefire/boost-ci/builds/43769849/job/4a9kgqgbb9dmiek0

Hence I only add it for GHA.