### PR TITLE
Add a full msvc-14.3 and reduce the windows coverage variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,8 +245,9 @@ jobs:
         include:
           - { toolset: msvc-14.0, cxxstd: '14,latest',      addrmd: '32,64', os: windows-2019 }
           - { toolset: msvc-14.2, cxxstd: '14,17,20',       addrmd: '32,64', os: windows-2019 }
+          - { toolset: msvc-14.3, cxxstd: '14,17,20,latest',addrmd: '32,64', os: windows-2022 }
           - { name: Collect coverage, coverage: yes,
-              toolset: msvc-14.3, cxxstd: '14,17,20',       addrmd: '32,64', os: windows-2022 }
+              toolset: msvc-14.3, cxxstd: 'latest',         addrmd: '64',    os: windows-2022 }
           - { toolset: clang-win, cxxstd: '14,17,latest',   addrmd: '32,64', os: windows-2022 }
           - { toolset: gcc,       cxxstd: '03,11,14,17,2a', addrmd: '64',    os: windows-2019 }
 


### PR DESCRIPTION
Collecting coverage data on Windows is VERY expensive (takes long).
So only do a 64-bit build with latest standard on msvc-14.3 by default.
Library authors can change that if required.