### PR TITLE
Add more tests using clang-win

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -86,9 +86,8 @@ environment:
       B2_TOOLSET: msvc-14.3
 
     - FLAVOR: clang-cl
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      B2_ADDRESS_MODEL: 64
-      B2_CXXSTD: 11,14,17
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      B2_CXXSTD: 11,14,17,latest
       B2_TOOLSET: clang-win
 
     - FLAVOR: cygwin (32-bit)

--- a/ci/build.bat
+++ b/ci/build.bat
@@ -21,8 +21,8 @@ set SELF_S=%SELF:\=/%
 IF NOT DEFINED B2_TARGETS (SET B2_TARGETS=libs/!SELF_S!/test)
 IF NOT DEFINED B2_JOBS (SET B2_JOBS=3)
 
-REM clang-win requires to use the linker for the manifest on Github Actions
-IF DEFINED GITHUB_ACTIONS IF "%B2_TOOLSET%" == "clang-win" (
+REM clang-win requires to use the linker for the manifest
+IF "%B2_TOOLSET%" == "clang-win" (
     IF NOT DEFINED B2_FLAGS (SET B2_FLAGS=embed-manifest-via=linker)
     ELSE (SET B2_FLAGS=embed-manifest-via=linker %B2_FLAGS%)
 )


### PR DESCRIPTION
Use C++latest standard and 32 bit builds using the "Visual Studio 2019" image
This also requires using the linker for the manifest.