### PR TITLE
pythonexecutable variable

### DIFF
--- a/ci/common_install.sh
+++ b/ci/common_install.sh
@@ -28,10 +28,18 @@ set -ex
 
 CI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 
+if command -v python ; then
+    export pythonexecutable="python"
+elif command -v python3 ; then
+    export pythonexecutable="python3"
+else
+    export pythonexecutable="python"
+fi
+
 . "$CI_DIR"/enforce.sh
 
 if [ -z "$SELF" ]; then
-    export SELF=$(python "$CI_DIR/get_libname.py")
+    export SELF=$($pythonexecutable "$CI_DIR/get_libname.py")
 fi
 
 # Handle also /refs/head/master
@@ -57,7 +65,7 @@ if [[ -n "$GIT_FETCH_JOBS" ]]; then
     DEPINST_ARGS+=("--git_args" "--jobs $GIT_FETCH_JOBS")
 fi
 
-python tools/boostdep/depinst/depinst.py --include benchmark --include example --include examples --include tools "${DEPINST_ARGS[@]}" $DEPINST $SELF
+$pythonexecutable tools/boostdep/depinst/depinst.py --include benchmark --include example --include examples --include tools "${DEPINST_ARGS[@]}" $DEPINST $SELF
 
 # Deduce B2_TOOLSET if unset from B2_COMPILER
 if [ -z "$B2_TOOLSET" ] && [ -n "$B2_COMPILER" ]; then

--- a/ci/enforce.sh
+++ b/ci/enforce.sh
@@ -10,6 +10,14 @@
 
 set -e
 
+if command -v python ; then
+    export pythonexecutable="python"
+elif command -v python3 ; then
+    export pythonexecutable="python3"
+else
+    export pythonexecutable="python"
+fi
+
 function enforce_b2
 {
     local old_varname=$1
@@ -48,7 +56,7 @@ fi
 
 # default parallel build jobs: number of CPUs available + 1
 if [ -z "${B2_JOBS}" ]; then
-    cpus=$(grep -c 'processor' /proc/cpuinfo || python -c 'import multiprocessing as mp; print(mp.cpu_count())' || echo "2")
+    cpus=$(grep -c 'processor' /proc/cpuinfo || $pythonexecutable -c 'import multiprocessing as mp; print(mp.cpu_count())' || echo "2")
     export B2_JOBS=$((cpus + 1))
 fi
 


### PR DESCRIPTION
New versions of Ubuntu and MacOSX don't have "python" or "python2" since that software is end-of-life.

Adding a detection mechanism in common_install.sh where if "python" is available, it will still use that, otherwise switch to "python3".   