### PR TITLE
GHA test, multiple values

### DIFF
--- a/.github/workflows/old_ci.yml
+++ b/.github/workflows/old_ci.yml
@@ -55,6 +55,20 @@ jobs:
               B2_LINKFLAGS: linkflags=-fsanitize=undefined linkflags=-fno-sanitize-recover=all linkflags=-fuse-ld=gold
             os: ubuntu-20.04
             install: g++-8
+          - name: New var usage, multiple values per key
+            env:
+              B2_CI_VERSION: 1
+              B2_TOOLSET: gcc-8
+              B2_ADDRESS_MODEL: 64
+              B2_LINK: shared,static
+              B2_THREADING: threading=multi,single
+              B2_VARIANT: release
+              # Possible (ab)usage
+              B2_CXXFLAGS: define=norecover
+              B2_DEFINES: BOOST_NO_STRESS_TEST=1 BOOST_IMPORTANT=1
+              B2_LINKFLAGS: -fsanitize=undefined -fno-sanitize-recover=all -fuse-ld=gold
+            os: ubuntu-20.04
+            install: g++-8
           - name: Travis-like coverage collection
             coverage: yes
             env:


### PR DESCRIPTION
Hi @Flamefire ,

old_ci.yml has a test called "Old var usage, multiple values per key" which demonstrates having more than one B2_LINKFLAG and B2_DEFINE. The resulting b2 command line is:

> ``` + ./b2 libs/boost-ci/test toolset=gcc-8 cxxstd=11 define=norecover define=BOOST_NO_STRESS_TEST=1 define=BOOST_IMPORTANT=1 linkflags=-fsanitize=undefined linkflags=-fno-sanitize-recover=all linkflags=-fuse-ld=gold address-model=64 link=shared,static threading=multi,single variant=release -j3 ```

And it builds successfully.  

What is the identical equivalent using "New var usage"?  It should output the same b2 command and build the same way, right?       You are welcome to modify the pull request, or create a different one.    
should the example also have multiple B2_CXXFLAGS?
