### PR TITLE
Handle multiple entries in `B2_DEFINES`

### DIFF
--- a/.github/workflows/old_ci.yml
+++ b/.github/workflows/old_ci.yml
@@ -55,6 +55,21 @@ jobs:
               B2_LINKFLAGS: linkflags=-fsanitize=undefined linkflags=-fno-sanitize-recover=all linkflags=-fuse-ld=gold
             os: ubuntu-20.04
             install: g++-8
+
+          - name: New var usage, multiple values per key
+            env:
+              B2_CI_VERSION: 1
+              B2_TOOLSET: gcc-8
+              B2_ADDRESS_MODEL: 64
+              B2_LINK: shared,static
+              B2_THREADING: threading=multi,single
+              B2_VARIANT: release
+              B2_DEFINES: BOOST_NO_STRESS_TEST=1 BOOST_IMPORTANT=1 BOOST_ALSO_IMPORTANT="with space"
+              B2_LINKFLAGS: -fsanitize=undefined -fno-sanitize-recover=all -fuse-ld=gold
+              B2_FLAGS: define=BOOST_CI_TEST_DEFINES=1
+            os: ubuntu-20.04
+            install: g++-8
+
           - name: Travis-like coverage collection
             coverage: yes
             env:

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -17,8 +17,27 @@
 // Check that including a file from the same directory works
 #include "test2.hpp"
 
+// Test of the CI scripts passing the correct defines
+#ifdef BOOST_CI_TEST_DEFINES
+    #ifndef BOOST_NO_STRESS_TEST
+        #error "Missing define BOOST_NO_STRESS_TEST"
+    #endif
+    #ifndef BOOST_IMPORTANT
+        #error "Missing define BOOST_IMPORTANT"
+    #endif
+    #ifndef BOOST_ALSO_IMPORTANT
+        #error "Missing define BOOST_ALSO_IMPORTANT"
+    #endif
+    #define BOOST_CI_STRINGIZE_2(x) #x
+    #define BOOST_CI_STRINGIZE(x) BOOST_CI_STRINGIZE_2(x)
+#endif
+
 int main()
 {
+#ifdef BOOST_CI_TEST_DEFINES
+    const std::string macro_value = BOOST_CI_STRINGIZE(BOOST_ALSO_IMPORTANT);
+    BOOST_TEST_EQ(macro_value, "with space");
+#endif
     const bool isMSVC = MSVC_VALUE;
     std::map<std::string, std::vector<int> > map;
     map["result"].push_back(boost::boost_ci::get_answer());


### PR DESCRIPTION
As pointed out by @sdarwin multiple values in `B2_DEFINES` led to a failing build as the scripts only supported a single value for the "new" var usages.
This is a regression from the old usage where `B2_DEFINES: define=FOO=1 define=BAR=2` could be used.
This is now fixed by a small parser function which generates multiple `define=*` entries and additionally now also supports spaces in the define values.
Same is done for `B2_INCLUDE` which has the same issue.

Also includes the change to the CI script from #177 and an additional test in test.cpp to verify that this works.

The hardest part was getting the splitting of defines right. I.e. the test `B2_DEFINES: BOOST_NO_STRESS_TEST=1 BOOST_IMPORTANT=1 BOOST_ALSO_IMPORTANT="with space"` should yield `define=BOOST_NO_STRESS_TEST=1 define=BOOST_IMPORTANT=1 define=BOOST_ALSO_IMPORTANT="with space"` and then also keep the quotes correct when b2 is invoked. I had trouble avoiding splitting it inside the quoted string or not at all leading to the equivalent of `define=BOOST_NO_STRESS_TEST="1 define=BOOST_IMPORTANT=1..."`