### PR TITLE
Refactor `drone.sh`

### DIFF
--- a/.drone/drone.sh
+++ b/.drone/drone.sh
@@ -6,75 +6,45 @@
 
 set -e
 
-export DRONE_BUILD_DIR=$(pwd)
-export VCS_COMMIT_ID=$DRONE_COMMIT
-export GIT_COMMIT=$DRONE_COMMIT
-export REPO_NAME=$DRONE_REPO
 export USER=$(whoami)
 export CC=${CC:-gcc}
 export PATH=~/.local/bin:/usr/local/bin:$PATH
-export TRAVIS_BUILD_DIR=$(pwd)
-export TRAVIS_BRANCH=$DRONE_BRANCH
-export TRAVIS_EVENT_TYPE=$DRONE_BUILD_EVENT
 
-common_install () {
-  git clone https://github.com/boostorg/boost-ci.git boost-ci-cloned --depth 1
-  [ "$(basename $REPO_NAME)" == "boost-ci" ] || cp -prf boost-ci-cloned/ci .
-  rm -rf boost-ci-cloned
+git clone https://github.com/boostorg/boost-ci.git boost-ci-cloned --depth 1
+[ "$(basename $DRONE_REPO)" == "boost-ci" ] || cp -prf boost-ci-cloned/ci .
+rm -rf boost-ci-cloned
 
-  if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-      unset -f cd
-  fi
-
-  export BOOST_CI_TARGET_BRANCH="$TRAVIS_BRANCH"
-  export BOOST_CI_SRC_FOLDER=$(pwd)
-
-  . ./ci/common_install.sh
-}
-
-if [ "$DRONE_JOB_BUILDTYPE" == "boost" ]; then
+export BOOST_CI_TARGET_BRANCH="$DRONE_BRANCH"
+export BOOST_CI_SRC_FOLDER=$(pwd)
+export CODECOV_NAME=${CODECOV_NAME:-"Drone CI"}
 
 echo '==================================> INSTALL'
-
-common_install
-
+. ./ci/common_install.sh
+echo "B2 config: $(env | grep B2_ || true)"
 echo '==================================> SCRIPT'
 
-. $BOOST_ROOT/libs/$SELF/ci/build.sh
-
-elif [ "$DRONE_JOB_BUILDTYPE" == "codecov" ]; then
-
-echo '==================================> INSTALL'
-
-common_install
-
-echo '==================================> SCRIPT'
-
-cd $BOOST_ROOT/libs/$SELF
-CODECOV_NAME="Drone CI" ci/travis/codecov.sh
-
-elif [ "$DRONE_JOB_BUILDTYPE" == "valgrind" ]; then
-
-echo '==================================> INSTALL'
-
-common_install
-
-echo '==================================> SCRIPT'
-
-cd $BOOST_ROOT/libs/$SELF
-ci/travis/valgrind.sh
-
-elif [ "$DRONE_JOB_BUILDTYPE" == "coverity" ]; then
-
-echo '==================================> INSTALL'
-
-common_install
-
-echo '==================================> SCRIPT'
-
-if  [ -n "${COVERITY_SCAN_NOTIFICATION_EMAIL}" -a \( "$TRAVIS_BRANCH" = "develop" -o "$TRAVIS_BRANCH" = "master" \) -a \( "$DRONE_BUILD_EVENT" = "push" -o "$DRONE_BUILD_EVENT" = "cron" \) ] ; then
-cd $BOOST_ROOT/libs/$SELF
-ci/travis/coverity.sh
-fi
-
-fi
+case "$DRONE_JOB_BUILDTYPE" in
+    boost)
+        $BOOST_ROOT/libs/$SELF/ci/build.sh
+        ;;
+    codecov)
+        $BOOST_ROOT/libs/$SELF/ci/travis/codecov.sh
+        ;;
+    valgrind)
+        $BOOST_ROOT/libs/$SELF/ci/travis/valgrind.sh
+        ;;
+    coverity)
+        if [ -z "$COVERITY_SCAN_NOTIFICATION_EMAIL" ] || [ -z "$COVERITY_SCAN_TOKEN" ]; then
+            echo "Coverity details not set up"
+            exit 1
+        fi
+        if [[ "DRONE_BRANCH" =~ ^(master|develop)$ ]] && [[ "DRONE_BUILD_EVENT" =~ ^(push|cron)$ ]]; then
+            export BOOST_REPO="$DRONE_REPO"
+			export BOOST_BRANCH="$DRONE_BRANCH"
+            $BOOST_ROOT/libs/$SELF/ci/coverity.sh
+        fi
+        ;;
+    *)
+        echo "Unknown build type: $DRONE_JOB_BUILDTYPE"
+        ;;
+esac


### PR DESCRIPTION
- Always source `common_install.sh`
- Move sourcing of `common_install.sh` outside a function to make sure set variables are there
- Use a switch-case for the build types
- Use simpler checks for coverity
- Remove TRAVIS variables

[skip ci]

Test at https://drone.cpp.al/boostorg/boost-ci/295