### PR TITLE
Drone: reduce size of functions.star output

### DIFF
--- a/ci/drone/functions.star
+++ b/ci/drone/functions.star
@@ -14,7 +14,8 @@ def download_from_boostCI(filename, boostCI_dir, out_dir=None):
     out_dir = boostCI_dir
   url = 'https://github.com/boostorg/boost-ci/raw/master/%s/%s' % (boostCI_dir, filename)
   target_path = '%s/%s' % (out_dir, filename)
-  return 'echo "Downloading {0} to {1}"; curl -s -S --retry 10 --create-dirs -L "{0}" -o "{1}" && chmod 755 {1}'.format(url, target_path)
+  # return 'echo "Downloading {0} to {1}"; curl -s -S --retry 10 --create-dirs -L "{0}" -o "{1}" && chmod 755 {1}'.format(url, target_path)
+  return 'curl -s -S --retry 10 --create-dirs -L "{0}" -o "{1}" && chmod 755 {1}'.format(url, target_path)
 
 # Common steps for unix systems
 # Takes the install script (inside the Boost.CI "ci/drone" folder) and the build script (relative to the root .drone folder)
@@ -22,7 +23,7 @@ def unix_common(install_script, buildscript_to_run):
   if not buildscript_to_run.endswith('.sh'):
     buildscript_to_run += '.sh'
   return [
-    "echo '==================================> SETUP'",
+    "echo '============> SETUP'",
     "uname -a",
     "export PATH=/usr/local/bin:$PATH",
     '\n'.join([
@@ -31,17 +32,17 @@ def unix_common(install_script, buildscript_to_run):
         # Install script
         download_from_boostCI(install_script, 'ci/drone'),
         # Default build script (if not exists) 
-        'if [ ! -e .drone/drone.sh ]; then %s; fi' % download_from_boostCI('drone.sh', '.drone'),
+        # 'if [ ! -e .drone/drone.sh ]; then %s; fi' % download_from_boostCI('drone.sh', '.drone'),
         # Chosen build script inside .drone (if a filename and does not exist)
-        'if [ "$(basename "{0}")" = "{0}" ] && [ ! -e .drone/{0} ]; then {1}; fi'.format(buildscript_to_run, download_from_boostCI(buildscript_to_run, '.drone')),
+        # 'if [ "$(basename "{0}")" = "{0}" ] && [ ! -e .drone/{0} ]; then {1}; fi'.format(buildscript_to_run, download_from_boostCI(buildscript_to_run, '.drone')),
       # Done
       'fi',
     ]),
 
-    "echo '==================================> PACKAGES'",
+    "echo '============> PACKAGES'",
     "ci/drone/" + install_script,
 
-    "echo '==================================> INSTALL AND TEST'",
+    "echo '============> INSTALL AND TEST'",
     ".drone/" + buildscript_to_run,
   ]
 
@@ -130,16 +131,16 @@ def windows_cxx(name, cxx="g++", cxxflags="", packages="", sources="", llvm_os="
         "privileged": privileged,
         "environment": environment_current,
         "commands": [
-          "echo '==================================> SETUP'",
+          "echo '============> SETUP'",
           "echo $env:DRONE_STAGE_MACHINE",
           "try { pwsh.exe -Command Invoke-WebRequest https://github.com/boostorg/boost-ci/archive/master.tar.gz -Outfile master.tar.gz -MaximumRetryCount 10 -RetryIntervalSec 15 } catch { Invoke-WebRequest https://github.com/boostorg/boost-ci/archive/master.tar.gz -Outfile master.tar.gz ; echo 'Using powershell' }",
           "tar -xvf master.tar.gz",
           "mv boost-ci-master .drone/boost-ci",
           "Remove-Item master.tar.gz",
-          "echo '==================================> PACKAGES'",
+          "echo '============> PACKAGES'",
           ".drone/boost-ci/ci/drone/windows-cxx-install.bat",
 
-          "echo '==================================> INSTALL AND COMPILE'",
+          "echo '============> INSTALL AND COMPILE'",
           "cmd /c .drone\\\%s.bat `& exit" % buildscript_to_run,
         ]
       }


### PR DESCRIPTION
boostorg/math reported their github issue number 849 "starlark: maximum file size exceeded"
Investigated on the drone server. The max size of a starlark file is 1MB.  Previously boostorg/math was generating a file of size 657604.  After recent updates of functions.star it exceeded 1MB. See below for an example snippet of output from boostorg/json. What seems to be happening is that starlark duplicates "everything" when it generates yaml, and sends the yaml to drone.  

So, it seems reasonable to backtrack a bit, and remove some code.  The update in this PR is on the drone server.

```
---
{"name": "Linux Clang 12 s390x", "kind": "pipeline", "type": "docker", "trigger": {"branch": ["master", "develop", "drone*", "bugfix/*", "feature/*", "fix/*", "pr/*"]}, "platform": {"os": "linux", "arch": "s390x"}, "clone": {"retries": 5}, "node": {}, "steps": [{"name": "Everything", "image": "cppalliance/droneubuntu2004:multiarch", "pull": "if-not-exists", "privileged": false, "environment": {"TRAVIS_BUILD_DIR": "/drone/src", "TRAVIS_OS_NAME": "linux", "CXX": "clang++-12", "CXXFLAGS": "", "PACKAGES": "clang-12 libstdc++-9-dev", "SOURCES": "", "LLVM_OS": "focal", "LLVM_VER": "12", "DRONE_JOB_BUILDTYPE": "boost", "B2_CI_VERSION": "1", "B2_VARIANT": "release", "B2_FLAGS": "warnings=extra warnings-as-errors=on", "B2_TOOLSET": "clang-12", "B2_CXXSTD": "17,20"}, "commands": ["echo '==================================> SETUP'", "uname -a", "export PATH=/usr/local/bin:$PATH", "if [ \"$(basename \"$DRONE_REPO\")\" != \"boost-ci\" ]; then\necho \"Downloading https://github.com/boostorg/boost-ci/raw/master/ci/drone/linux-cxx-install.sh to ci/drone/linux-cxx-install.sh\"; curl -s -S --retry 10 --create-dirs -L \"https://github.com/boostorg/boost-ci/raw/master/ci/drone/linux-cxx-install.sh\" -o \"ci/drone/linux-cxx-install.sh\" \u0026\u0026 chmod 755 ci/drone/linux-cxx-install.sh\nif [ ! -e .drone/drone.sh ]; then echo \"Downloading https://github.com/boostorg/boost-ci/raw/master/.drone/drone.sh to .drone/drone.sh\"; curl -s -S --retry 10 --create-dirs -L \"https://github.com/boostorg/boost-ci/raw/master/.drone/drone.sh\" -o \".drone/drone.sh\" \u0026\u0026 chmod 755 .drone/drone.sh; fi\nif [ \"$(basename \"drone.sh\")\" = \"drone.sh\" ] \u0026\u0026 [ ! -e .drone/drone.sh ]; then echo \"Downloading https://github.com/boostorg/boost-ci/raw/master/.drone/drone.sh to .drone/drone.sh\"; curl -s -S --retry 10 --create-dirs -L \"https://github.com/boostorg/boost-ci/raw/master/.drone/drone.sh\" -o \".drone/drone.sh\" \u0026\u0026 chmod 755 .drone/drone.sh; fi\nfi", "echo '==================================> PACKAGES'", "ci/drone/linux-cxx-install.sh", "echo '==================================> INSTALL AND TEST'", ".drone/drone.sh"]}]}
---
{"name": "Linux gcc 11 s390x", "kind": "pipeline", "type": "docker", "trigger": {"branch": ["master", "develop", "drone*", "bugfix/*", "feature/*", "fix/*", "pr/*"]}, "platform": {"os": "linux", "arch": "s390x"}, "clone": {"retries": 5}, "node": {}, "steps": [{"name": "Everything", "image": "cppalliance/droneubuntu2004:multiarch", "pull": "if-not-exists", "privileged": false, "environment": {"TRAVIS_BUILD_DIR": "/drone/src", "TRAVIS_OS_NAME": "linux", "CXX": "g++-11", "CXXFLAGS": "", "PACKAGES": "g++-11", "SOURCES": "", "LLVM_OS": "", "LLVM_VER": "", "DRONE_JOB_BUILDTYPE": "boost", "B2_CI_VERSION": "1", "B2_VARIANT": "release", "B2_FLAGS": "warnings=extra warnings-as-errors=on", "B2_TOOLSET": "gcc-11", "B2_CXXSTD": "17,2a"}, "commands": ["echo '==================================> SETUP'", "uname -a", "export PATH=/usr/local/bin:$PATH", "if [ \"$(basename \"$DRONE_REPO\")\" != \"boost-ci\" ]; then\necho \"Downloading https://github.com/boostorg/boost-ci/raw/master/ci/drone/linux-cxx-install.sh to ci/drone/linux-cxx-install.sh\"; curl -s -S --retry 10 --create-dirs -L \"https://github.com/boostorg/boost-ci/raw/master/ci/drone/linux-cxx-install.sh\" -o \"ci/drone/linux-cxx-install.sh\" \u0026\u0026 chmod 755 ci/drone/linux-cxx-install.sh\nif [ ! -e .drone/drone.sh ]; then echo \"Downloading https://github.com/boostorg/boost-ci/raw/master/.drone/drone.sh to .drone/drone.sh\"; curl -s -S --retry 10 --create-dirs -L \"https://github.com/boostorg/boost-ci/raw/master/.drone/drone.sh\" -o \".drone/drone.sh\" \u0026\u0026 chmod 755 .drone/drone.sh; fi\nif [ \"$(basename \"drone.sh\")\" = \"drone.sh\" ] \u0026\u0026 [ ! -e .drone/drone.sh ]; then echo \"Downloading https://github.com/boostorg/boost-ci/raw/master/.drone/drone.sh to .drone/drone.sh\"; curl -s -S --retry 10 --create-dirs -L \"https://github.com/boostorg/boost-ci/raw/master/.drone/drone.sh\" -o \".drone/drone.sh\" \u0026\u0026 chmod 755 .drone/drone.sh; fi\nfi", "echo '==================================> PACKAGES'", "ci/drone/linux-cxx-install.sh", "echo '==================================> INSTALL AND TEST'", ".drone/drone.sh"]}]}
---
...
...
```