### PR TITLE
Drone: macOS m1 arm64

### DIFF
--- a/ci/drone/functions.star
+++ b/ci/drone/functions.star
@@ -214,6 +214,7 @@ def osx_cxx(
     if not osx_version:
         if xcode_version[0:2] in [ "14", "13"]:
             osx_version="monterey"
+            arch="arm64"
         elif xcode_version[0:4] in [ "12.5"]:
             osx_version="monterey"
         elif xcode_version[0:2] in [ "12","11","10"]:


### PR DESCRIPTION
The macOS Monterey machines are m1 architecture, which is natively arm64.  However, this platform can also emulate x86.  In fact that is what was happening. The drone runner was in x86 mode.     
- Re-installed arm64 drone version.  
-  Set the architecture flag in functions.star to arm64 when it's hitting these machines.
  
Seems to be working correctly now.