### PR TITLE
Add variable BOOST_CI_CODECOV_IO_UPLOAD to allow skipping section

### DIFF
--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -83,24 +83,27 @@ elif [[ "$1" == "upload" ]]; then
     # pull request)
     lcov --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE} --list coverage.info
 
-    #
-    # upload to codecov.io
-    #
-    curl -Os https://uploader.codecov.io/latest/linux/codecov
-    
-    # Verify Download
-    if command -v gpg &> /dev/null && command -v gpgv &> /dev/null; then
-        curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+    if [[ "$BOOST_CI_CODECOV_IO_UPLOAD" != "skip" ]]; then
+        #
+        # upload to codecov.io
+        #
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
 
-        curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-        curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+        # Verify Download
+        if command -v gpg &> /dev/null && command -v gpgv &> /dev/null; then
+            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
 
-        gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-        shasum -a 256 -c codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+
+            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM
+        fi
+
+        chmod +x codecov
+        ./codecov --verbose --nonZero ${CODECOV_NAME:+--name "$CODECOV_NAME"} -f coverage.info -X search
+        # end of [[ "$BOOST_CI_CODECOV_IO_UPLOAD" != "skip" ]] section
     fi
-
-    chmod +x codecov
-    ./codecov --verbose --nonZero ${CODECOV_NAME:+--name "$CODECOV_NAME"} -f coverage.info -X search
 else
     echo "Invalid parameter for codecov.sh: '$1'." >&2
     false


### PR DESCRIPTION
We are generating code coverage reports for repos such as boostorg/url and cppalliance/http_proto, in the pull requests.   Example: https://673.url.prtest.cppalliance.org/genhtml/index.html  
This is done by calling boost-ci codecov.sh. However only the first half of the codecov script is necessary to install and run lcov.   The second part, that actually uploads to codecov, will purposely fail due to a lack of a token.   

The most convenient solution that comes to mind is to allow skipping the "upload to codecov" part.   Just add a simple conditional.  That is proposed in this pull request.  Let me know if it's ok.  

Another idea is to restructure the scripts in some other ways.  For example, move the lcov section to it's own file.   But that might be overkill and not required.  
