### PR TITLE
Adjust xargs command in codecov.sh

### DIFF
--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -74,7 +74,7 @@ elif [[ "$1" == "upload" ]]; then
     for f in `for f in include/boost/*; do echo $f; done | cut -f2- -d/`; do echo "*/$f*"; done > /tmp/interesting
     echo headers that matter:
     cat /tmp/interesting
-    xargs -L 999999 -a /tmp/interesting lcov --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE} --extract all.info {} "*/libs/$SELF/*" --output-file coverage.info
+    xargs --verbose -L 999999 -a /tmp/interesting lcov --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE} --extract all.info "*/libs/$SELF/*" --output-file coverage.info
 
     # dump a summary on the console - helps us identify problems in pathing
     # note this has test file coverage in it - if you do not want to count test


### PR DESCRIPTION
In codecov.sh , remove `{}` from xargs and add `--verbose` flag for clarity.

Often, xargs will be called using the flag `-I replace-str` , such as `-I {}`.   Most likely that was the original intention.  However without `-I`, lcov reports a warning/error about  `{}` .
