### PR TITLE
Drone caching: modify "git pull" step

### DIFF
--- a/ci/common_install.sh
+++ b/ci/common_install.sh
@@ -51,7 +51,8 @@ if [ ! -d boost-root ]; then
 else
     cd boost-root
     git checkout $BOOST_BRANCH
-    git pull
+    git pull --no-recurse-submodules
+    git submodule update
 fi
 
 git submodule update -q --init tools/boostdep


### PR DESCRIPTION
An unexpected error is occurring with drone caching.  The cache for boostorg/url is a few weeks old. Restore from cache. This appears when refreshing the boostorg/build submodule:
```
fatal: remote error: upload-pack: not our ref 19127b75621f423b572281f27b92ce4c7e50f1b5
```
The odd thing is the boostorg/build happens to already be up-to-date, so it won't actually be updated or changed.    "19127b75621f423b572281f27b92ce4c7e50f1b5" is a mystery, and isn't the commit sha (either before or after).

Modifying:
```
git pull
```
to 
```
git pull --no-recurse-submodules
git submodule update
```
fixed the problem in an isolated test, so I will check that in and proceed.  
what is the difference between those methods...  