### PR TITLE
Remove use of ubuntu-18.04 image and update container jobs

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -44,31 +44,31 @@ parameters:
   - name: jobs
     type: object
     default:
-      - { compiler: gcc-4.8,   cxxstd: '11',       os: ubuntu-18.04 }
-      - { compiler: gcc-4.9,   cxxstd: '11',       os: ubuntu-18.04, container: 'ubuntu:16.04' }
-      - { compiler: gcc-5,     cxxstd: '11',       os: ubuntu-18.04 }
-      - { compiler: gcc-6,     cxxstd: '11,14',    os: ubuntu-18.04 }
-      - { compiler: gcc-7,     cxxstd: '11,14,17', os: ubuntu-18.04 }
+      - { compiler: gcc-4.8,   cxxstd: '11',       os: ubuntu-22.04, container: 'ubuntu:16.04' }
+      - { compiler: gcc-4.9,   cxxstd: '11',       os: ubuntu-22.04, container: 'ubuntu:16.04' }
+      - { compiler: gcc-5,     cxxstd: '11',       os: ubuntu-22.04, container: 'ubuntu:18.04' }
+      - { compiler: gcc-6,     cxxstd: '11,14',    os: ubuntu-22.04, container: 'ubuntu:18.04' }
+      - { compiler: gcc-7,     cxxstd: '11,14,17', os: ubuntu-20.04 }
       - { compiler: gcc-8,     cxxstd: '14,17,2a', os: ubuntu-20.04 }
       - { compiler: gcc-9,     cxxstd: '14,17,2a', os: ubuntu-20.04 }
       - { compiler: gcc-10,    cxxstd: '14,17,20', os: ubuntu-20.04 }
       - { compiler: gcc-11,    cxxstd: '14,17,20', os: ubuntu-20.04 }
-      - { compiler: clang-3.5, cxxstd: '11',       os: ubuntu-18.04, container: 'ubuntu:16.04' }
-      - { compiler: clang-3.6, cxxstd: '11',       os: ubuntu-18.04, container: 'ubuntu:16.04' }
-      - { compiler: clang-3.7, cxxstd: '11',       os: ubuntu-18.04, container: 'ubuntu:16.04' }
-      - { compiler: clang-3.8, cxxstd: '11,14',    os: ubuntu-18.04, container: 'ubuntu:16.04' }
-      - { compiler: clang-3.9, cxxstd: '11,14',    os: ubuntu-18.04 }
-      - { compiler: clang-4.0, cxxstd: '11,14',    os: ubuntu-18.04 }
-      - { compiler: clang-5.0, cxxstd: '11,14,17', os: ubuntu-18.04 }
-      - { compiler: clang-6.0, cxxstd: '11,14,17', os: ubuntu-18.04, install: 'clang-6.0 libc6-dbg libc++-dev libc++abi-dev libstdc++-8-dev' }
-      - { compiler: clang-7,   cxxstd: '14,17',    os: ubuntu-18.04, install: 'clang-7 libc6-dbg libc++-dev libstdc++-8-dev' }
-      - { compiler: clang-8,   cxxstd: '14,17',    os: ubuntu-18.04, install: 'clang-8 libc6-dbg libc++-dev libstdc++-8-dev' }
+      - { compiler: clang-3.5, cxxstd: '11',       os: ubuntu-22.04, container: 'ubuntu:16.04' }
+      - { compiler: clang-3.6, cxxstd: '11',       os: ubuntu-22.04, container: 'ubuntu:16.04' }
+      - { compiler: clang-3.7, cxxstd: '11',       os: ubuntu-22.04, container: 'ubuntu:16.04' }
+      - { compiler: clang-3.8, cxxstd: '11,14',    os: ubuntu-22.04, container: 'ubuntu:16.04' }
+      - { compiler: clang-3.9, cxxstd: '11,14',    os: ubuntu-22.04, container: 'ubuntu:16.04' }
+      - { compiler: clang-4.0, cxxstd: '11,14',    os: ubuntu-22.04, container: 'ubuntu:16.04' }
+      - { compiler: clang-5.0, cxxstd: '11,14,17', os: ubuntu-22.04, container: 'ubuntu:16.04' }
+      - { compiler: clang-6.0, cxxstd: '11,14,17', os: ubuntu-20.04, install: 'clang-6.0 libc6-dbg libc++-dev libc++abi-dev libstdc++-8-dev' }
+      - { compiler: clang-7,   cxxstd: '14,17',    os: ubuntu-20.04, install: 'clang-7 libc6-dbg libc++-dev libstdc++-8-dev' }
+      - { compiler: clang-8,   cxxstd: '14,17',    os: ubuntu-20.04, install: 'clang-8 libc6-dbg libc++-dev libstdc++-8-dev' }
       - { compiler: clang-9,   cxxstd: '14,17,2a', os: ubuntu-20.04 }
       - { compiler: clang-10,  cxxstd: '14,17,20', os: ubuntu-20.04 }
-      - { compiler: clang-11,  cxxstd: '14,17,20', os: ubuntu-20.04 }
-      - { compiler: clang-12,  cxxstd: '14,17,20', os: ubuntu-20.04 }
+      - { compiler: clang-11,  cxxstd: '14,17,20', os: ubuntu-22.04 }
+      - { compiler: clang-12,  cxxstd: '14,17,20', os: ubuntu-22.04 }
       - { name: Linux_clang_6_libcxx,
-          compiler: clang-6.0, cxxstd: '11,14,17', os: ubuntu-18.04, install: 'clang-6.0 libc6-dbg libc++-dev libc++abi-dev libstdc++-8-dev', env: {B2_STDLIB: libc++ } }
+          compiler: clang-6.0, cxxstd: '11,14,17', os: ubuntu-20.04, install: 'clang-6.0 libc6-dbg libc++-dev libc++abi-dev libstdc++-8-dev', env: {B2_STDLIB: libc++ } }
       # OSX
       - { compiler: clang, cxxstd: '14,17,2a',    os: macOS-11, xcode: '11.7' }
       - { compiler: clang, cxxstd: '14,17,2a',    os: macOS-11, xcode: '12.4' }

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -44,31 +44,31 @@ parameters:
   - name: jobs
     type: object
     default:
-      - { compiler: gcc-4.8,   cxxstd: '11',       os: ubuntu-22.04, container: 'ubuntu:16.04' }
-      - { compiler: gcc-4.9,   cxxstd: '11',       os: ubuntu-22.04, container: 'ubuntu:16.04' }
-      - { compiler: gcc-5,     cxxstd: '11',       os: ubuntu-22.04, container: 'ubuntu:18.04' }
-      - { compiler: gcc-6,     cxxstd: '11,14',    os: ubuntu-22.04, container: 'ubuntu:18.04' }
+      - { compiler: gcc-4.8,   cxxstd: '11',       os: ubuntu-20.04, container: 'ubuntu:16.04' }
+      - { compiler: gcc-4.9,   cxxstd: '11',       os: ubuntu-20.04, container: 'ubuntu:16.04' }
+      - { compiler: gcc-5,     cxxstd: '11',       os: ubuntu-20.04, container: 'ubuntu:18.04' }
+      - { compiler: gcc-6,     cxxstd: '11,14',    os: ubuntu-20.04, container: 'ubuntu:18.04' }
       - { compiler: gcc-7,     cxxstd: '11,14,17', os: ubuntu-20.04 }
       - { compiler: gcc-8,     cxxstd: '14,17,2a', os: ubuntu-20.04 }
       - { compiler: gcc-9,     cxxstd: '14,17,2a', os: ubuntu-20.04 }
       - { compiler: gcc-10,    cxxstd: '14,17,20', os: ubuntu-20.04 }
       - { compiler: gcc-11,    cxxstd: '14,17,20', os: ubuntu-20.04 }
-      - { compiler: clang-3.5, cxxstd: '11',       os: ubuntu-22.04, container: 'ubuntu:16.04' }
-      - { compiler: clang-3.6, cxxstd: '11',       os: ubuntu-22.04, container: 'ubuntu:16.04' }
-      - { compiler: clang-3.7, cxxstd: '11',       os: ubuntu-22.04, container: 'ubuntu:16.04' }
-      - { compiler: clang-3.8, cxxstd: '11,14',    os: ubuntu-22.04, container: 'ubuntu:16.04' }
-      - { compiler: clang-3.9, cxxstd: '11,14',    os: ubuntu-22.04, container: 'ubuntu:16.04' }
-      - { compiler: clang-4.0, cxxstd: '11,14',    os: ubuntu-22.04, container: 'ubuntu:16.04' }
-      - { compiler: clang-5.0, cxxstd: '11,14,17', os: ubuntu-22.04, container: 'ubuntu:16.04' }
-      - { compiler: clang-6.0, cxxstd: '11,14,17', os: ubuntu-20.04, install: 'clang-6.0 libc6-dbg libc++-dev libc++abi-dev libstdc++-8-dev' }
-      - { compiler: clang-7,   cxxstd: '14,17',    os: ubuntu-20.04, install: 'clang-7 libc6-dbg libc++-dev libstdc++-8-dev' }
-      - { compiler: clang-8,   cxxstd: '14,17',    os: ubuntu-20.04, install: 'clang-8 libc6-dbg libc++-dev libstdc++-8-dev' }
+      - { compiler: clang-3.5, cxxstd: '11',       os: ubuntu-20.04, container: 'ubuntu:16.04' }
+      - { compiler: clang-3.6, cxxstd: '11',       os: ubuntu-20.04, container: 'ubuntu:16.04' }
+      - { compiler: clang-3.7, cxxstd: '11',       os: ubuntu-20.04, container: 'ubuntu:16.04' }
+      - { compiler: clang-3.8, cxxstd: '11,14',    os: ubuntu-20.04, container: 'ubuntu:16.04' }
+      - { compiler: clang-3.9, cxxstd: '11,14',    os: ubuntu-20.04, container: 'ubuntu:16.04' }
+      - { compiler: clang-4.0, cxxstd: '11,14',    os: ubuntu-20.04, container: 'ubuntu:16.04' }
+      - { compiler: clang-5.0, cxxstd: '11,14,17', os: ubuntu-20.04, container: 'ubuntu:16.04' }
+      - { compiler: clang-6.0, cxxstd: '11,14,17', os: ubuntu-20.04 }
+      - { compiler: clang-7,   cxxstd: '14,17',    os: ubuntu-20.04 }
+      - { compiler: clang-8,   cxxstd: '14,17',    os: ubuntu-20.04 }
       - { compiler: clang-9,   cxxstd: '14,17,2a', os: ubuntu-20.04 }
       - { compiler: clang-10,  cxxstd: '14,17,20', os: ubuntu-20.04 }
       - { compiler: clang-11,  cxxstd: '14,17,20', os: ubuntu-22.04 }
       - { compiler: clang-12,  cxxstd: '14,17,20', os: ubuntu-22.04 }
       - { name: Linux_clang_6_libcxx,
-          compiler: clang-6.0, cxxstd: '11,14,17', os: ubuntu-20.04, install: 'clang-6.0 libc6-dbg libc++-dev libc++abi-dev libstdc++-8-dev', env: {B2_STDLIB: libc++ } }
+          compiler: clang-6.0, cxxstd: '11,14,17', os: ubuntu-20.04, container: 'ubuntu:18.04', install: 'clang-6.0 libc++-dev libc++abi-dev', env: {B2_STDLIB: libc++ } }
       # OSX
       - { compiler: clang, cxxstd: '14,17,2a',    os: macOS-11, xcode: '11.7' }
       - { compiler: clang, cxxstd: '14,17,2a',    os: macOS-11, xcode: '12.4' }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,15 +43,15 @@ jobs:
       matrix:
         include:
           # Linux, gcc
-          - { compiler: gcc-4.4,   cxxstd: '98,0x',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
-          - { compiler: gcc-4.6,   cxxstd: '03,0x',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
-          - { compiler: gcc-4.7,   cxxstd: '03,11',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
-          - { compiler: gcc-4.8,   cxxstd: '03,11',          os: ubuntu-22.04, container: 'ubuntu:18.04' }
-          - { compiler: gcc-4.9,   cxxstd: '03,11',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
+          - { compiler: gcc-4.4,   cxxstd: '98,0x',          os: ubuntu-22.04, container: 'ubuntu:16.04' }
+          - { compiler: gcc-4.6,   cxxstd: '03,0x',          os: ubuntu-22.04, container: 'ubuntu:16.04' }
+          - { compiler: gcc-4.7,   cxxstd: '03,11',          os: ubuntu-22.04, container: 'ubuntu:16.04' }
+          - { compiler: gcc-4.8,   cxxstd: '03,11',          os: ubuntu-22.04, container: 'ubuntu:16.04' }
+          - { compiler: gcc-4.9,   cxxstd: '03,11',          os: ubuntu-22.04, container: 'ubuntu:16.04' }
           - { compiler: gcc-5,     cxxstd: '03,11,14,1z',    os: ubuntu-22.04, container: 'ubuntu:18.04' }
           - { compiler: gcc-6,     cxxstd: '03,11,14,17',    os: ubuntu-22.04, container: 'ubuntu:18.04' }
-          - { compiler: gcc-7,     cxxstd: '03,11,14,17',    os: ubuntu-22.04, container: 'ubuntu:18.04' }
-          - { compiler: gcc-8,     cxxstd: '03,11,14,17,2a', os: ubuntu-22.04, container: 'ubuntu:18.04' }
+          - { compiler: gcc-7,     cxxstd: '03,11,14,17',    os: ubuntu-20.04 }
+          - { compiler: gcc-8,     cxxstd: '03,11,14,17,2a', os: ubuntu-20.04 }
           - { compiler: gcc-9,     cxxstd: '03,11,14,17,2a', os: ubuntu-20.04 }
           - { compiler: gcc-10,    cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
           - { compiler: gcc-11,    cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
@@ -62,10 +62,10 @@ jobs:
               compiler: gcc-8,     cxxstd: '03,11',          os: ubuntu-20.04, install: 'g++-8-multilib', address-model: '32,64' }
 
           # Linux, clang
-          - { compiler: clang-3.5, cxxstd: '03,11',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
-          - { compiler: clang-3.6, cxxstd: '03,11,14',       os: ubuntu-20.04, container: 'ubuntu:16.04' }
-          - { compiler: clang-3.7, cxxstd: '03,11,14',       os: ubuntu-20.04, container: 'ubuntu:16.04' }
-          - { compiler: clang-3.8, cxxstd: '03,11,14',       os: ubuntu-20.04, container: 'ubuntu:16.04' }
+          - { compiler: clang-3.5, cxxstd: '03,11',          os: ubuntu-22.04, container: 'ubuntu:16.04' }
+          - { compiler: clang-3.6, cxxstd: '03,11,14',       os: ubuntu-22.04, container: 'ubuntu:16.04' }
+          - { compiler: clang-3.7, cxxstd: '03,11,14',       os: ubuntu-22.04, container: 'ubuntu:16.04' }
+          - { compiler: clang-3.8, cxxstd: '03,11,14',       os: ubuntu-22.04, container: 'ubuntu:16.04' }
           - { compiler: clang-3.9, cxxstd: '03,11,14',       os: ubuntu-22.04, container: 'ubuntu:18.04' }
           - { compiler: clang-4.0, cxxstd: '03,11,14',       os: ubuntu-22.04, container: 'ubuntu:18.04' }
           - { compiler: clang-5.0, cxxstd: '03,11,14,1z',    os: ubuntu-22.04, container: 'ubuntu:18.04' }


### PR DESCRIPTION
This was removed on AzP (likely together with the GHA one).
Update `os` where possible, use `container` where not.
Use Ubuntu 22.04 as the base OS for containers consistently.