### PR TITLE
LCOV_VERSION variable

### DIFF
--- a/.github/workflows/old_ci.yml
+++ b/.github/workflows/old_ci.yml
@@ -87,6 +87,16 @@ jobs:
               B2_LINKFLAGS: linkflags=-fuse-ld=gold
             os: ubuntu-20.04
             install: g++-8
+          - name: Coverage LCOV v2.0
+            coverage: yes
+            os: ubuntu-22.04
+            install: 'libcapture-tiny-perl libdatetime-perl'
+            address-model: '32,64'
+            env:
+              B2_TOOLSET: gcc-12
+              B2_CXXSTD: 14,17
+              B2_DEFINES: define=BOOST_NO_STRESS_TEST=1
+              LCOV_VERSION: 'v2.0'
 
     name: ${{matrix.name}}
     timeout-minutes: 120

--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -53,9 +53,16 @@ elif [[ "$1" == "upload" ]]; then
     fi
 
     # install the latest lcov we know works
+    : ${LCOV_VERSION:=v1.15}
+
+    if [[ "$LCOV_VERSION" =~ ^v[2-9] ]]; then
+        LCOV_OPTIONS="${LCOV_OPTIONS} --ignore-errors unused"
+        LCOV_OPTIONS=$(echo ${LCOV_OPTIONS} | xargs echo)
+    fi
+
     rm -rf /tmp/lcov
     cd /tmp
-    git clone --depth 1 -b v1.15 https://github.com/linux-test-project/lcov.git
+    git clone --depth 1 -b ${LCOV_VERSION} https://github.com/linux-test-project/lcov.git
     export PATH=/tmp/lcov/bin:$PATH
     command -v lcov
     lcov --version
@@ -65,7 +72,7 @@ elif [[ "$1" == "upload" ]]; then
     : "${LCOV_BRANCH_COVERAGE:=1}" # Set default
 
     # coverage files are in ../../b2 from this location
-    lcov --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE} --gcov-tool=$GCOV --directory "$BOOST_ROOT" --capture --output-file all.info
+    lcov ${LCOV_OPTIONS} --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE} --gcov-tool=$GCOV --directory "$BOOST_ROOT" --capture --output-file all.info
     # dump a summary on the console
     lcov --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE} --list all.info
 


### PR DESCRIPTION
Here is a phased approach to adding a newer LCOV.  

It will default to v1.15, the same as before. The user may opt to set LCOV_VERSION, manually choosing a different version.   
 It's their responsibility to install any extra packages libcapture-tiny-perl libdatetime-perl .    An example of how to use LCOV v2.0 is included in github actions.

To consider in the future:

 codecov.sh detects if the `apt` or `yum` command is available, attempts to install perl packages, continues with an informational warning if package installation fails.  
 
 