### PR TITLE
Add apt wrapper scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,7 @@ jobs:
             SOURCE_KEYS=(${{join(matrix.source_keys, ' ')}})
             SOURCES=(${{join(matrix.sources, ' ')}})
             # Add this by default
+            SOURCE_KEYS+=('http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F')
             SOURCES+=(ppa:ubuntu-toolchain-r/test)
 
             ci/add-apt-keys.sh "${SOURCE_KEYS[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,17 +161,10 @@ jobs:
             SOURCES=(${{join(matrix.sources, ' ')}})
             # Add this by default
             SOURCES+=(ppa:ubuntu-toolchain-r/test)
-            for key in "${SOURCE_KEYS[@]}"; do
-                for i in {1..$NET_RETRY_COUNT}; do
-                    keyfilename=$(basename -s .key $key)
-                    curl -sSL --retry ${NET_RETRY_COUNT:-5} "$key" | sudo gpg --dearmor > /etc/apt/trusted.gpg.d/${keyfilename} && break || sleep 10
-                done
-            done
-            for source in "${SOURCES[@]}"; do
-                for i in {1..$NET_RETRY_COUNT}; do
-                    sudo add-apt-repository $source && break || sleep 10
-                done
-            done
+
+            ci/add-apt-keys.sh "${SOURCE_KEYS[@]}"
+            ci/add-apt-repositories.sh "${SOURCES[@]}"
+
             sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
             if [[ -z "${{matrix.install}}" ]]; then
                 pkgs="${{matrix.compiler}}"

--- a/ci/add-apt-keys.sh
+++ b/ci/add-apt-keys.sh
@@ -1,0 +1,35 @@
+#! /bin/bash
+#
+# Copyright 2023 Alexander Grund
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+#      http://www.boost.org/LICENSE_1_0.txt)
+#
+# Add APT keys
+# - Each argument should be a key URL
+# - $NET_RETRY_COUNT is the amount of retries attempted
+
+set -eu
+
+function do_add_key
+{
+    key_url=$1
+    # If a keyserver URL (e.g. http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F)
+    # use the hash as the filename,
+    # else assume the URL contains a filename, e.g. https://apt.llvm.org/llvm-snapshot.gpg.key
+    if [[ "$key_url" =~ .*keyserver.*search=0x([A-F0-9]+) ]]; then
+        keyfilename="${BASH_REMATCH[1]}.key"
+    else
+        keyfilename=$(basename -s .key "$key_url")
+    fi
+    echo -e "\tDownloading APT key from '$key_url' to '$keyfilename'"
+    for i in {1..${NET_RETRY_COUNT:-3}}; do
+        curl -sSL --retry ${NET_RETRY_COUNT:-5} "$key_url" | sudo gpg --dearmor > /etc/apt/trusted.gpg.d/${keyfilename} && return 0 || sleep 10
+    done
+
+    return 1 # Failed
+}
+
+for key_url in "$@"; do
+    do_add_key "$key_url"
+done

--- a/ci/add-apt-keys.sh
+++ b/ci/add-apt-keys.sh
@@ -24,7 +24,7 @@ function do_add_key
     fi
     echo -e "\tDownloading APT key from '$key_url' to '$keyfilename'"
     for i in {1..${NET_RETRY_COUNT:-3}}; do
-        curl -sSL --retry ${NET_RETRY_COUNT:-5} "$key_url" | sudo gpg --dearmor > /etc/apt/trusted.gpg.d/${keyfilename} && return 0 || sleep 10
+        curl -sSL --retry ${NET_RETRY_COUNT:-5} "$key_url" | sudo gpg --dearmor -o "/etc/apt/trusted.gpg.d/${keyfilename}" && return 0 || sleep 10
     done
 
     return 1 # Failed

--- a/ci/add-apt-repositories.sh
+++ b/ci/add-apt-repositories.sh
@@ -1,0 +1,25 @@
+#! /bin/bash
+#
+# Copyright 2023 Alexander Grund, Sam Darwin
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+#      http://www.boost.org/LICENSE_1_0.txt)
+#
+# Add APT keys, i.e. wrapper around add-apt-repository
+# - Each argument should be a repository name
+# - $NET_RETRY_COUNT is the amount of retries attempted
+
+set -eu
+
+function do_add_repository {
+    name=$1
+    echo -e "\tAdding repository $name"
+    for i in {1..${NET_RETRY_COUNT:-3}}; do
+        sudo -E apt-add-repository -y "$name" && return 0 || sleep 10;
+    done
+    return 1 # Failed
+}
+
+for repo_name in "$@"; do
+    do_add_repository "$repo_name"
+done


### PR DESCRIPTION
Add scripts to securely add APT keys and repositories as wrappers over the raw commands. This fixes various issues with the approach in the current CI script. E.g. in 

```
for key in "${SOURCE_KEYS[@]}"; do
    for i in {1..$NET_RETRY_COUNT}; do
        keyfilename=$(basename -s .key $key)
        curl -sSL --retry ${NET_RETRY_COUNT:-5} "$key" | sudo gpg --dearmor > /etc/apt/trusted.gpg.d/${keyfilename} && break || sleep 10
    done
done
```

- After all retries failed the code will continue instead of failing (same for adding repos)
- The write may fail with a permission denied if the executing user isn't already root: `sudo` applies to the command, not the redirection and hence doesn't help here as `gpg --dearmor` runs fine without it. One would need to pipe it into `sudo tee` or use `gpg -o` parameter (which I chose)
- Adding a key from a URL which doesn't contain a filename fails as `basename` can't extract something meaningful