### PR TITLE
Fix incompatibility of Clang 13+ after GHA image update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,9 @@ jobs:
           - { compiler: clang-10,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
           - { compiler: clang-11,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
           - { compiler: clang-12,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
-          - { compiler: clang-13,  cxxstd: '03,11,14,17,20', os: ubuntu-22.04 }
-          - { compiler: clang-14,  cxxstd: '03,11,14,17,20', os: ubuntu-22.04 }
+          # Clang isn't compatible with libstdc++-13, so use the slightly older one
+          - { compiler: clang-13,  cxxstd: '03,11,14,17,20', os: ubuntu-22.04, install: 'clang-13 g++-12', gcc_toolchain: 12 }
+          - { compiler: clang-14,  cxxstd: '03,11,14,17,20', os: ubuntu-22.04, install: 'clang-14 g++-12', gcc_toolchain: 12 }
 
           # libc++
           - { compiler: clang-6.0, cxxstd: '03,11,14',       os: ubuntu-22.04, container: 'ubuntu:18.04', stdlib: libc++, install: 'clang-6.0 libc++-dev libc++abi-dev' }


### PR DESCRIPTION
Fixes errors such as
```
In file included from /home/runner/boost-root/libs/redis/include/boost/redis/config.hpp:11:
34/usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/chrono:2320:48: error: call to consteval function 'std::chrono::hh_mm_ss::_S_fractional_width' is not a constant expression
35        static constexpr unsigned fractional_width = {_S_fractional_width()};
36                                                      ^
37/usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/chrono:2320:48: note: undefined function '_S_fractional_width' cannot be used in a constant expression
38/usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/chrono:2275:2: note: declared here
39        _S_fractional_width()
40        ^
```

Using the container as suggested by @pdimov  is problematic due to the install commands for containers that would need adjustments after replacements upstream leading to 

> Package python is not available, but is referred to by another package.
> This may mean that the package is missing, has been obsoleted, or
> is only available from another source
> However the following packages replace it:
>   2to3 python2-minimal python2 dh-python python-is-python3
> 
> Package libpython-dev is not available, but is referred to by another package.
> This may mean that the package is missing, has been obsoleted, or
> is only available from another source
> However the following packages replace it:
>   libpython2-dev
> 
> E: Package 'python' has no installation candidate
> E: Package 'libpython-dev' has no installation candidate