### PR TITLE
get_libname: Support a list of libraries in libraries.json

### DIFF
--- a/ci/get_libname.py
+++ b/ci/get_libname.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python 
 
+# Copyright Alexander Grund 2021-2023
+#
+# Distributed under the Boost Software License, Version 1.0.
+# https://www.boost.org/LICENSE_1_0.txt
+
 import json
 import os
 import sys

--- a/ci/get_libname.py
+++ b/ci/get_libname.py
@@ -1,8 +1,15 @@
 #!/usr/bin/env python 
 
-import os
 import json
+import os
+import sys
 
 with open(os.path.join(os.environ['BOOST_CI_SRC_FOLDER'], 'meta', 'libraries.json')) as jsonFile:
     lib_data = json.load(jsonFile)
+    if isinstance(lib_data, (list, tuple)):
+      if len(lib_data) > 1:
+        sys.stderr.write('Found multiple libraries in meta/libraries.json. Assuming first entry is the main one.\n')
+      else:
+        sys.stderr.write('Unwrapping list with single entry in meta/libraries.json.\n')
+      lib_data = lib_data[0]
     print(lib_data['key'])


### PR DESCRIPTION
Currently the script expects `libraries.json` to contain a dict with the library metadata.
However it can contain information about multiple sub-libraries, e.g. in Boost.Utility or Boost.Functional in which case the top-level struct is a list containing a dict for each sub-library. It is also possible to wrap the single dict in a list with a single item which should be equivalent to having the dict at the top-level.

Modify the script to detect such a list and work on the first entry.


See https://github.com/boostorg/math/pull/1061#issuecomment-1867749395 for motivation of this change