### PR TITLE
Drone: Set $COVERITY_SCAN_NOTIFICATION_EMAIL and $COVERITY_SCAN_TOKEN defaults

### DIFF
--- a/ci/drone/functions.star
+++ b/ci/drone/functions.star
@@ -454,6 +454,9 @@ def job_impl(
     buildtype = 'boost'
   elif buildtype == 'codecov':
     env.setdefault('CODECOV_TOKEN', {'from_secret': 'codecov_token'})
+  elif buildtype == 'coverity':
+    env.setdefault('COVERITY_SCAN_NOTIFICATION_EMAIL', {'from_secret': 'coverity_scan_email'})
+    env.setdefault('COVERITY_SCAN_TOKEN', {'from_secret': 'coverity_scan_token'})
 
   # Put common args of all *_cxx calls not modified below into kwargs to avoid duplicating them
   kwargs['arch'] = arch


### PR DESCRIPTION
Use a similar mechanism to codecov to set the token and EMail from secrets

@sdarwin Please merge and deploy

Also someone would need to add the secrets to Drone of this repo or approve me for https://scan.coverity.com/projects/24440 so I can do that. But don't know who the "project owner" is. @pdimov maybe?