### PR TITLE
GHA: Cache boost checkout

### DIFF
--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -480,8 +480,8 @@ jobs:
           COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
 
       - name: Prepare for cache
-        if: ${{ env.BOOST_ROOT != '' }}
-        run: rm -rf boost-root; mv "${BOOST_ROOT}" boost-root
+        if: ${{ env.BOOST_ROOT_CACHE != '' }}
+        run: rm -rf boost-root; mv "${BOOST_ROOT_CACHE}" boost-root
         working-directory: ${{github.workspace}}
 
   generate-windows-matrix:

--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -417,6 +417,13 @@ jobs:
           BDDE_EDITION: ${{matrix.edition}}
           BDDE_ARCH: ${{matrix.arch}}
 
+      - name: Cache Boost checkout
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: boost-root
+          key: boost-checkout-cache-${{matrix.os}}-${{matrix.container}}-${{github.sha}}
+          restore-keys: boost-checkout-cache-${{matrix.os}}-${{matrix.container}}-
+
       - name: Setup Boost
         run: source ci/github/install.sh
         env:
@@ -471,6 +478,11 @@ jobs:
         env:
           COVERITY_SCAN_NOTIFICATION_EMAIL: ${{ secrets.COVERITY_SCAN_NOTIFICATION_EMAIL }}
           COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+
+      - name: Prepare for cache
+        if: ${{ env.BOOST_ROOT != '' }}
+        run: rm -rf boost-root; mv "${BOOST_ROOT}" boost-root
+        working-directory: ${{github.workspace}}
 
   generate-windows-matrix:
     runs-on: ubuntu-latest

--- a/ci/common_install.sh
+++ b/ci/common_install.sh
@@ -304,7 +304,7 @@ if [[ "${B2_DONT_BOOTSTRAP:0}" != "1" ]]; then
     # Check if b2 already exists. This would (only) happen in a caching scenario. The purpose of caching is to save time by not recompiling everything.
     # The user may clear cache or delete b2 beforehand if they wish to rebuild.
     if [ ! -f b2 ] || ! b2_version_output=$(./b2 --version); then
-        ${B2_WRAPPER:-} ./bootstrap.sh
+        time ${B2_WRAPPER:-} ./bootstrap.sh
     else
         # b2 expects versions to match
         engineversion=$(echo "$b2_version_output" | tr -s ' ' | cut -d' ' -f2 | cut -d'-' -f1)
@@ -320,7 +320,7 @@ if [[ "${B2_DONT_BOOTSTRAP:0}" != "1" ]]; then
             else
                 echo "Unable to extract B2 version from $b2_version_output"
             fi
-            ${B2_WRAPPER:-} ./bootstrap.sh
+            time ${B2_WRAPPER:-} ./bootstrap.sh
         fi
     fi
     trap - ERR

--- a/ci/common_install.sh
+++ b/ci/common_install.sh
@@ -313,6 +313,11 @@ if [[ "${B2_DONT_BOOTSTRAP:0}" != "1" ]]; then
         if [[ "${enginemajorversion}" == "${coremajorversion}" ]] && [[ "${engineminorversion}" == "${coreminorversion}" ]]; then
             echo "b2 already exists and has the same version number"
         else
+            if [[ "$engineversion" =~ ^[0-9]\.[0-9]\. ]]; then
+                echo "b2 binary version: $enginemajorversion:$engineminorversion vs source version $coremajorversion:$coreminorversion"
+            else
+                echo "Unable to extract B2 version from $b2_version_output"
+            fi
             ${B2_WRAPPER:-} ./bootstrap.sh
         fi
     fi

--- a/ci/common_install.sh
+++ b/ci/common_install.sh
@@ -81,6 +81,8 @@ else
     export BOOST_BRANCH="develop"
 fi
 
+# CI cache might have restored the boost-root folder in the current directory
+[ ! -d boost-root ] || mv boost-root ..
 cd ..
 
 if [ ! -d boost-root ]; then

--- a/ci/github/install.sh
+++ b/ci/github/install.sh
@@ -40,6 +40,11 @@ fi
 # shellcheck disable=SC1091
 . "$(dirname "${BASH_SOURCE[0]}")"/../common_install.sh
 
+# Save the state before building anything to avoid caching build artefacts
+BOOST_ROOT_CACHE="${BOOST_ROOT}-for-cache"
+echo "BOOST_ROOT_CACHE=$BOOST_ROOT_CACHE" >> $GITHUB_ENV
+cp -r "$BOOST_ROOT" "$BOOST_ROOT_CACHE"
+
 # Persist the environment for all future steps
 
 # Set by common_install.sh


### PR DESCRIPTION
Instead of cloning the Boost main repository and later potentially many submodules (by `depinst.py`) we can cache the last checkout.

On any changes the checkout-and-pull should update it to the appropriate version.

Closes #240