### PR TITLE
Drone: Allow passing `privileged` to `job_impl` and set for tsan by default

### DIFF
--- a/ci/drone/functions.star
+++ b/ci/drone/functions.star
@@ -415,13 +415,13 @@ def job_impl(
     env.setdefault('VALGRIND_OPTS', '--error-exitcode=1')
 
   if asan:
-    privileged = True
+    kwargs['privileged'] = True
     env.update({
       'B2_ASAN': '1',
       'DRONE_EXTRA_PRIVILEGED': 'True',
     })
-  else:
-    privileged = False
+  elif tsan:
+    kwargs.setdefault('privileged', True)
 
   if ubsan:
     env['B2_UBSAN'] = '1'
@@ -479,7 +479,7 @@ def job_impl(
       kwargs['llvm_os'] = names[image.split('ubuntu')[-1].split(':')[0]] # get part between 'ubuntu' and ':'
       kwargs['llvm_ver'] = compiler.split('-')[1]
 
-    return linux_cxx(name, cxx, packages=packages, image=image, privileged=privileged, **kwargs)
+    return linux_cxx(name, cxx, packages=packages, image=image, **kwargs)
   elif os.startswith('freebsd'):
     # Deduce version if os is `freebsd-<version>`
     parts = os.split('freebsd-')

--- a/ci/drone/functions.star
+++ b/ci/drone/functions.star
@@ -414,15 +414,14 @@ def job_impl(
       testflags = 'testing.launcher=valgrind'
     env.setdefault('VALGRIND_OPTS', '--error-exitcode=1')
 
-  if asan:
+  if asan or tsan:
     kwargs['privileged'] = True
-    env.update({
-      'B2_ASAN': '1',
-      'DRONE_EXTRA_PRIVILEGED': 'True',
-    })
-  elif tsan:
-    kwargs.setdefault('privileged', True)
+  # Set env var if privileged is set by any means
+  if kwargs['privileged']:
+    env['DRONE_EXTRA_PRIVILEGED'] = 'True'
 
+  if absan:
+    env['B2_ASAN'] = '1'
   if ubsan:
     env['B2_UBSAN'] = '1'
   if tsan:


### PR DESCRIPTION
This is required such that changing the KASLR is allowed.

Generalized such that `job_impl` accepts the `privileged` parameter in case it needs changes by users

@sdarwin Can you review and deploy this please?