### PR TITLE
Allow C++ language levels to be excluded more easily in the posix matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,73 +41,78 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        exclude:
+          # eliminate support for older C++ versions if needed:
+          - cxxstd: '98'
+          - cxxstd: '03'
         include:
-          # Linux, gcc
-          - { compiler: gcc-4.4,   cxxstd: '98,0x',          os: ubuntu-latest, container: 'ubuntu:16.04' }
-          - { compiler: gcc-4.6,   cxxstd: '03,0x',          os: ubuntu-latest, container: 'ubuntu:16.04' }
-          - { compiler: gcc-4.7,   cxxstd: '03,11',          os: ubuntu-latest, container: 'ubuntu:16.04' }
-          - { compiler: gcc-4.8,   cxxstd: '03,11',          os: ubuntu-latest, container: 'ubuntu:16.04' }
-          - { compiler: gcc-4.9,   cxxstd: '03,11',          os: ubuntu-latest, container: 'ubuntu:16.04' }
-          - { compiler: gcc-5,     cxxstd: '03,11,14,1z',    os: ubuntu-latest, container: 'ubuntu:18.04' }
-          - { compiler: gcc-6,     cxxstd: '03,11,14,17',    os: ubuntu-latest, container: 'ubuntu:18.04' }
-          - { compiler: gcc-7,     cxxstd: '03,11,14,17',    os: ubuntu-20.04 }
-          - { compiler: gcc-8,     cxxstd: '03,11,14,17,2a', os: ubuntu-20.04 }
-          - { compiler: gcc-9,     cxxstd: '03,11,14,17,2a', os: ubuntu-20.04 }
-          - { compiler: gcc-10,    cxxstd: '03,11,14,17,20', os: ubuntu-22.04 }
-          - { compiler: gcc-11,    cxxstd: '03,11,14,17,20', os: ubuntu-22.04 }
-          - { compiler: gcc-12,    cxxstd: '03,11,14,17,20', os: ubuntu-22.04 }
-          - { compiler: gcc-13,    cxxstd: '11,14,17,20,2b', os: ubuntu-24.04 }
-          - { compiler: gcc-14,    cxxstd: '11,14,17,20,2b', os: ubuntu-24.04 }
+          # linux, gcc
+          - { compiler: gcc-4.3,   cxxstd: ['98'                              ], os: ubuntu-latest, container: 'ubuntu:16.04' }
+          - { compiler: gcc-4.4,   cxxstd: ['03','0x'                         ], os: ubuntu-latest, container: 'ubuntu:16.04' }
+          - { compiler: gcc-4.6,   cxxstd: ['03','0x'                         ], os: ubuntu-latest, container: 'ubuntu:16.04' }
+          - { compiler: gcc-4.7,   cxxstd: ['03','11'                         ], os: ubuntu-latest, container: 'ubuntu:16.04' }
+          - { compiler: gcc-4.8,   cxxstd: ['03','11'                         ], os: ubuntu-latest, container: 'ubuntu:16.04' }
+          - { compiler: gcc-4.9,   cxxstd: ['03','11'                         ], os: ubuntu-latest, container: 'ubuntu:16.04' }
+          - { compiler: gcc-5,     cxxstd: ['03','11','14','1z'               ], os: ubuntu-latest, container: 'ubuntu:18.04' }
+          - { compiler: gcc-6,     cxxstd: ['03','11','14','17'               ], os: ubuntu-latest, container: 'ubuntu:18.04' }
+          - { compiler: gcc-7,     cxxstd: ['03','11','14','17'               ], os: ubuntu-20.04 }
+          - { compiler: gcc-8,     cxxstd: ['03','11','14','17','2a'          ], os: ubuntu-20.04 }
+          - { compiler: gcc-9,     cxxstd: ['03','11','14','17','2a'          ], os: ubuntu-20.04 }
+          - { compiler: gcc-10,    cxxstd: ['03','11','14','17','20'          ], os: ubuntu-22.04 }
+          - { compiler: gcc-11,    cxxstd: ['03','11','14','17','20'          ], os: ubuntu-22.04 }
+          - { compiler: gcc-12,    cxxstd: ['03','11','14','17','20'          ], os: ubuntu-22.04 }
+          - { compiler: gcc-13,    cxxstd: [     '11','14','17','20','2b'     ], os: ubuntu-24.04 }
+          - { compiler: gcc-14,    cxxstd: [     '11','14','17','20','2b'     ], os: ubuntu-24.04 }
           - { name: GCC w/ sanitizers, sanitize: yes,
-              compiler: gcc-13,    cxxstd: '03,11,14,17,20', os: ubuntu-24.04 }
+              compiler: gcc-13,    cxxstd: ['03','11','14','17','20','2b'     ], os: ubuntu-24.04 }
           - { name: Collect coverage, coverage: yes,
-              compiler: gcc-13,    cxxstd: '03,2b',          os: ubuntu-24.04, install: 'g++-13-multilib', address-model: '32,64' }
+              compiler: gcc-13,    cxxstd: ['03',                    '2b'     ], os: ubuntu-24.04, install: 'g++-13-multilib', address-model: '32,64' }
 
           # Linux, clang
-          - { compiler: clang-3.5, cxxstd: '03,11',          os: ubuntu-latest, container: 'ubuntu:16.04' }
-          - { compiler: clang-3.6, cxxstd: '03,11,14',       os: ubuntu-latest, container: 'ubuntu:16.04' }
-          - { compiler: clang-3.7, cxxstd: '03,11,14',       os: ubuntu-latest, container: 'ubuntu:16.04' }
-          - { compiler: clang-3.8, cxxstd: '03,11,14',       os: ubuntu-latest, container: 'ubuntu:16.04' }
-          - { compiler: clang-3.9, cxxstd: '03,11,14',       os: ubuntu-latest, container: 'ubuntu:18.04' }
-          - { compiler: clang-4.0, cxxstd: '03,11,14',       os: ubuntu-latest, container: 'ubuntu:18.04' }
-          - { compiler: clang-5.0, cxxstd: '03,11,14,1z',    os: ubuntu-latest, container: 'ubuntu:18.04' }
-          - { compiler: clang-6.0, cxxstd: '03,11,14,17',    os: ubuntu-20.04 }
-          - { compiler: clang-7,   cxxstd: '03,11,14,17',    os: ubuntu-20.04 }
+          - { compiler: clang-3.5, cxxstd: ['03','11'                         ], os: ubuntu-latest, container: 'ubuntu:16.04' }
+          - { compiler: clang-3.6, cxxstd: ['03','11','14'                    ], os: ubuntu-latest, container: 'ubuntu:16.04' }
+          - { compiler: clang-3.7, cxxstd: ['03','11','14'                    ], os: ubuntu-latest, container: 'ubuntu:16.04' }
+          - { compiler: clang-3.8, cxxstd: ['03','11','14'                    ], os: ubuntu-latest, container: 'ubuntu:16.04' }
+          - { compiler: clang-3.9, cxxstd: ['03','11','14'                    ], os: ubuntu-latest, container: 'ubuntu:18.04' }
+          - { compiler: clang-4.0, cxxstd: ['03','11','14'                    ], os: ubuntu-latest, container: 'ubuntu:18.04' }
+          - { compiler: clang-5.0, cxxstd: ['03','11','14','1z'               ], os: ubuntu-latest, container: 'ubuntu:18.04' }
+          - { compiler: clang-6.0, cxxstd: ['03','11','14','17'               ], os: ubuntu-20.04 }
+          - { compiler: clang-7,   cxxstd: ['03','11','14','17'               ], os: ubuntu-20.04 }
           # Note: clang-8 does not fully support C++20, so it is not compatible with some libstdc++ versions in this mode
-          - { compiler: clang-8,   cxxstd: '03,11,14,17,2a', os: ubuntu-20.04 , install: 'clang-8 g++-7', gcc_toolchain: 7 }
-          - { compiler: clang-9,   cxxstd: '03,11,14,17,2a', os: ubuntu-20.04 }
-          - { compiler: clang-10,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
-          - { compiler: clang-11,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
-          - { compiler: clang-12,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
+          - { compiler: clang-8,   cxxstd: ['03','11','14','17','2a'          ], os: ubuntu-20.04 , install: 'clang-8 g++-7', gcc_toolchain: 7 }
+          - { compiler: clang-9,   cxxstd: ['03','11','14','17','2a'          ], os: ubuntu-20.04 }
+          - { compiler: clang-10,  cxxstd: ['03','11','14','17','20'          ], os: ubuntu-20.04 }
+          - { compiler: clang-11,  cxxstd: ['03','11','14','17','20'          ], os: ubuntu-20.04 }
+          - { compiler: clang-12,  cxxstd: ['03','11','14','17','20'          ], os: ubuntu-20.04 }
           # Clang isn't compatible with libstdc++-13, so use the slightly older one
-          - { compiler: clang-13,  cxxstd: '03,11,14,17,20', os: ubuntu-22.04, install: 'clang-13 g++-12', gcc_toolchain: 12 }
-          - { compiler: clang-14,  cxxstd: '03,11,14,17,20', os: ubuntu-22.04, install: 'clang-14 g++-12', gcc_toolchain: 12 }
-          - { compiler: clang-15,  cxxstd: '03,11,14,17,20', os: ubuntu-22.04, install: 'clang-15 g++-12', gcc_toolchain: 12 }
-          - { compiler: clang-16,  cxxstd: '11,14,17,20,2b', os: ubuntu-24.04 }
+          - { compiler: clang-13,  cxxstd: ['03','11','14','17','20'          ], os: ubuntu-22.04, install: 'clang-13 g++-12', gcc_toolchain: 12 }
+          - { compiler: clang-14,  cxxstd: ['03','11','14','17','20'          ], os: ubuntu-22.04, install: 'clang-14 g++-12', gcc_toolchain: 12 }
+          - { compiler: clang-15,  cxxstd: ['03','11','14','17','20'          ], os: ubuntu-22.04, install: 'clang-15 g++-12', gcc_toolchain: 12 }
+          - { compiler: clang-16,  cxxstd: [     '11','14','17','20','2b'     ], os: ubuntu-24.04 }
           # https://github.com/llvm/llvm-project/issues/59827: disabled 2b/23 for clang-17 with libstdc++13 in 24.04
-          - { compiler: clang-17,  cxxstd: '11,14,17,20',    os: ubuntu-24.04 }
-          - { compiler: clang-18,  cxxstd: '11,14,17,20,23,2c', os: ubuntu-24.04 }
+          - { compiler: clang-17,  cxxstd: [     '11','14','17','20'          ], os: ubuntu-24.04 }
+          - { compiler: clang-18,  cxxstd: [     '11','14','17','20','23','2c'], os: ubuntu-24.04 }
 
           # libc++
-          - { compiler: clang-6.0, cxxstd: '03,11,14',       os: ubuntu-latest, container: 'ubuntu:18.04', stdlib: libc++, install: 'clang-6.0 libc++-dev libc++abi-dev' }
-          - { compiler: clang-7,   cxxstd: '03,11,14,17',    os: ubuntu-20.04, stdlib: libc++, install: 'clang-7 libc++-7-dev libc++abi-7-dev' }
+          - { compiler: clang-6.0, cxxstd: ['03','11','14'                    ], os: ubuntu-latest, container: 'ubuntu:18.04', stdlib: libc++, install: 'clang-6.0 libc++-dev libc++abi-dev' }
+          - { compiler: clang-7,   cxxstd: ['03','11','14','17'               ], os: ubuntu-20.04, stdlib: libc++, install: 'clang-7 libc++-7-dev libc++abi-7-dev' }
           - { name: Clang w/ sanitizers, sanitize: yes,
-              compiler: clang-12,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04, stdlib: libc++, install: 'clang-12 libc++-12-dev libc++abi-12-dev' }
+              compiler: clang-12,  cxxstd: ['03','11','14','17','20'          ], os: ubuntu-20.04, stdlib: libc++, install: 'clang-12 libc++-12-dev libc++abi-12-dev' }
 
           - { name: MacOS w/ clang and sanitizers,
-              compiler: clang,     cxxstd: '03,11,14,17,20,2b', os: macos-13, sanitize: yes }
-          - { compiler: clang,     cxxstd: '03,11,14,17,20,2b', os: macos-14 }
-          - { compiler: clang,     cxxstd: '03,11,14,17,20,2b', os: macos-15 }
+              compiler: clang,     cxxstd: ['03','11','14','17','20','2b'     ], os: macos-13, sanitize: yes }
+          - { compiler: clang,     cxxstd: ['03','11','14','17','20','2b'     ], os: macos-14 }
+          - { compiler: clang,     cxxstd: ['03','11','14','17','20','2b'     ], os: macos-15 }
 
           # Coverity Scan
           # requires two github secrets in repo to activate; see ci/github/coverity.sh
           # does not run on pull requests, only on pushes into develop and master
           - { name: Coverity, coverity: yes,
-              compiler: clang-12,  cxxstd: '03,20',          os: ubuntu-20.04, ccache: no }
+              compiler: clang-12,  cxxstd: ['03',               '20'          ], os: ubuntu-20.04, ccache: no }
 
           # multiarch (bigendian testing) - does not support coverage yet
           - { name: Big-endian, multiarch: yes,
-              compiler: clang,     cxxstd: '17',             os: ubuntu-22.04, ccache: no, distro: fedora, edition: 34, arch: s390x }
+              compiler: clang,     cxxstd: [               '17'               ], os: ubuntu-22.04, ccache: no, distro: fedora, edition: 34, arch: s390x }
 
 
     timeout-minutes: 120
@@ -229,7 +234,7 @@ jobs:
         env:
           B2_ADDRESS_MODEL: ${{matrix.address-model}}
           B2_COMPILER: ${{matrix.compiler}}
-          B2_CXXSTD: ${{matrix.cxxstd}}
+          B2_CXXSTD: ${{ join(matrix.cxxstd, ',') }}
           B2_SANITIZE: ${{matrix.sanitize}}
           B2_STDLIB: ${{matrix.stdlib}}
           # More entries can be added in the same way, see the B2_ARGS assignment in ci/enforce.sh for the possible keys.
@@ -286,7 +291,7 @@ jobs:
           - { name: Collect coverage, coverage: yes,
               toolset: msvc-14.3, cxxstd: 'latest',         addrmd: '64',    os: windows-2022 }
           - { toolset: clang-win, cxxstd: '14,17,latest',   addrmd: '32,64', os: windows-2022 }
-          - { toolset: gcc,       cxxstd: '03,11,14,17,2a', addrmd: '64',    os: windows-2019 }
+          - { toolset: gcc,       cxxstd: '03','11','14','17','2a', addrmd: '64',    os: windows-2019 }
 
     runs-on: ${{matrix.os}}
 


### PR DESCRIPTION
This allows someone to disable cxxstd=03 more easily in the posix matrix.  Just experimenting to see if it's useful.
I dropped the cxxstd=98 job as part of this.