### PR TITLE
Disable CCache if installation or setup fails

### DIFF
--- a/ci/common_install.sh
+++ b/ci/common_install.sh
@@ -2,7 +2,7 @@
 #
 # Copyright 2017 - 2019 James E. King III
 # Copyright 2019 Mateusz Loskot <mateusz at loskot dot net>
-# Copyright 2020 Alexander Grund
+# Copyright 2020-2024 Alexander Grund
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 #      http://www.boost.org/LICENSE_1_0.txt)
@@ -122,7 +122,19 @@ fi
 
 # Setup ccache
 if [ "$B2_USE_CCACHE" == "1" ]; then
-    "$CI_DIR"/setup_ccache.sh
+    if ! "$CI_DIR"/setup_ccache.sh 2>&1; then
+        set +x
+        echo
+        printf '=%.0s' {1..120}
+        echo
+        echo "Failed to install & setup ccache!"
+        echo "Will NOT use CCache for building."
+        printf '=%.0s' {1..120}
+        echo
+        echo
+        B2_USE_CCACHE=0
+        set -x
+    fi
 fi
 
 # Set up user-config to actually use B2_COMPILER if set

--- a/ci/setup_ccache.sh
+++ b/ci/setup_ccache.sh
@@ -1,30 +1,41 @@
 #!/bin/bash
 #
-# Copyright 2021 Alexander Grund
+# Copyright 2021-2024 Alexander Grund
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 #      http://www.boost.org/LICENSE_1_0.txt)
 #
 # Installs and sets up ccache
 
-set -ex
+set -eu
+set +x
 
 if ! command -v ccache &> /dev/null; then
   if [ -f "/etc/debian_version" ]; then
     sudo apt-get install ${NET_RETRY_COUNT:+ -o Acquire::Retries=$NET_RETRY_COUNT} -y ccache
   elif command -v brew &> /dev/null; then
     brew update > /dev/null
-    if ! brew install ccache; then
+    if ! brew install ccache 2>&1; then
+        echo "Installing CCache via Homebrew failed."
+        echo "Cleaning up Python binaries and trying again"
         # Workaround issue with unexpected symlinks: https://github.com/actions/runner-images/issues/6817
         for f in 2to3 idle3 pydoc3 python3 python3-config; do
             rm /usr/local/bin/$f || true
         done
         # Try again
-        brew install ccache
+        brew install ccache 2>&1
     fi
   fi
 fi
-ccache --set-config=cache_dir=${B2_CCACHE_DIR:-~/.ccache}
-ccache --set-config=max_size=${B2_CCACHE_SIZE:-500M}
+
+# Sanity check that CCache is installed, executable and works at all
+ccache --version
+
+# This also sets the default values
+echo "Using cache directory of size ${B2_CCACHE_SIZE:=500M} at '${B2_CCACHE_DIR:=$HOME/.ccache}'"
+
+
+ccache --set-config=cache_dir="$B2_CCACHE_DIR"
+ccache --set-config=max_size="$B2_CCACHE_SIZE"
 ccache -z
 echo "CCache config: $(ccache -p)"


### PR DESCRIPTION
On MacOS 13 the Homebrew CCache installation was seen to error with a segmentation fault.
As CCache is not essential for building just show a (very) visibile error message and disable it.