### PR TITLE
Clear CCache directory on possible corruption

### DIFF
--- a/ci/common_install.sh
+++ b/ci/common_install.sh
@@ -38,6 +38,10 @@ print_on_gha "::group::Setup B2 variables"
 . "$CI_DIR"/enforce.sh
 print_on_gha "::endgroup::"
 
+            echo "::group::My title"
+            echo "Inside group"
+            echo "::endgroup::"
+
 print_on_gha "::group::Checkout and setup Boost build tree"
 pythonexecutable=$(get_python_executable)
 

--- a/ci/common_install.sh
+++ b/ci/common_install.sh
@@ -144,6 +144,7 @@ if [ "$B2_USE_CCACHE" == "1" ]; then
         echo
         echo
         B2_USE_CCACHE=0
+        print_on_gha "::error title=CCache::CCache disabled due to an error!"
         set -x
     fi
 fi

--- a/ci/setup_ccache.sh
+++ b/ci/setup_ccache.sh
@@ -42,7 +42,7 @@ ccache --version
 # This also sets the default values
 echo "Using cache directory of size ${B2_CCACHE_SIZE:=500M} at '${B2_CCACHE_DIR:=$HOME/.ccache}'"
 
-if ! ccache -z &> /dev/null; then
+if false ; then # ! ccache -z &> /dev/null; then
   print_on_gha "::warning title=CCache::Possible cache corruption detected!"
   # Might happen if the cache got corrupted
   echo "Clearing possibly corrupted CCache directory"

--- a/ci/setup_ccache.sh
+++ b/ci/setup_ccache.sh
@@ -42,6 +42,12 @@ ccache --version
 # This also sets the default values
 echo "Using cache directory of size ${B2_CCACHE_SIZE:=500M} at '${B2_CCACHE_DIR:=$HOME/.ccache}'"
 
+if ! ccache -z &> /dev/null; then
+  print_on_gha "::warning title=CCache::Possible cache corruption detected!"
+  # Might happen if the cache got corrupted
+  echo "Clearing possibly corrupted CCache directory"
+  rm -rf "$B2_CCACHE_DIR" "$HOME/.ccache"
+fi
 
 ccache --set-config=cache_dir="$B2_CCACHE_DIR"
 ccache --set-config=max_size="$B2_CCACHE_SIZE"

--- a/ci/setup_ccache.sh
+++ b/ci/setup_ccache.sh
@@ -10,7 +10,14 @@
 set -eu
 set +x
 
+function print_on_gha {
+    if [[ "${GITHUB_ACTIONS:-false}" == "true" ]]; then
+        echo "$@"
+    fi
+} 2> /dev/null
+
 if ! command -v ccache &> /dev/null; then
+  print_on_gha "::group::Installing CCache"
   if [ -f "/etc/debian_version" ]; then
     sudo apt-get install ${NET_RETRY_COUNT:+ -o Acquire::Retries=$NET_RETRY_COUNT} -y ccache
   elif command -v brew &> /dev/null; then
@@ -26,6 +33,7 @@ if ! command -v ccache &> /dev/null; then
         brew install ccache 2>&1
     fi
   fi
+  print_on_gha "::endgroup::"
 fi
 
 # Sanity check that CCache is installed, executable and works at all


### PR DESCRIPTION

CCache might segfault on e.g. MacOS which can be resolved by clearing the cache.
This might be done by deleting the GitHub Actions cache but as there is one for each build it might become cumbersome.
So delete the folder inside the setup script when `ccache -z` (simplest command that triggered the segfault) fails.