### PR TITLE
Skip CI builds (GHA, Appveyor) on README updates.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,6 +33,12 @@ branches:
     - /fix\/.*/
     - /pr\/.*/
 
+skip_commits:
+  files:
+    - LICENSE
+    - meta/*
+    - README.md
+
 matrix:
   fast_finish: false
   # Adding MAYFAIL to any matrix job allows it to fail but the build stays green:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ on:
       - feature/**
       - fix/**
       - pr/**
+    paths-ignore:
+      - LICENSE
+      - meta/**
+      - README.md
 
 concurrency:
   group: ${{format('{0}:{1}', github.repository, github.ref)}}


### PR DESCRIPTION
Does not trigger CI when only files in the list are updated.

References:

[Appveyor](https://www.appveyor.com/docs/how-to/filtering-commits/#commit-files-github-and-bitbucket-only)
[GitHub Actions](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore)

Tested in boostorg/assign by committing these changes and then committing changes only to the README.md file; in this case CI did not run in GHA or Appveyor.