### PR TITLE
Use stdlibc++ 11 for Clang 13&14 and automatically install selected GCC toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,15 +78,15 @@ jobs:
           - { compiler: clang-6.0, cxxstd: '11,14,17',       os: ubuntu-20.04 }
           - { compiler: clang-7,   cxxstd: '11,14,17',       os: ubuntu-20.04 }
           # Note: clang-8 does not fully support C++20, so it is not compatible with some libstdc++ versions in this mode
-          - { compiler: clang-8,   cxxstd: '11,14,17,2a',    os: ubuntu-20.04 , install: 'clang-8 g++-7', gcc_toolchain: 7 }
+          - { compiler: clang-8,   cxxstd: '11,14,17,2a',    os: ubuntu-20.04 , gcc_toolchain: 7 }
           - { compiler: clang-9,   cxxstd: '11,14,17,2a',    os: ubuntu-20.04 }
           - { compiler: clang-10,  cxxstd: '11,14,17,20',    os: ubuntu-20.04 }
           - { compiler: clang-11,  cxxstd: '11,14,17,20',    os: ubuntu-20.04 }
           - { compiler: clang-12,  cxxstd: '11,14,17,20',    os: ubuntu-20.04 }
           # Clang isn't compatible with libstdc++-13, so use the slightly older one
-          - { compiler: clang-13,  cxxstd: '11,14,17,20',    os: ubuntu-22.04, install: 'clang-13 g++-12', gcc_toolchain: 12 }
-          - { compiler: clang-14,  cxxstd: '11,14,17,20',    os: ubuntu-22.04, install: 'clang-14 g++-12', gcc_toolchain: 12 }
-          - { compiler: clang-15,  cxxstd: '11,14,17,20',    os: ubuntu-22.04, install: 'clang-15 g++-12', gcc_toolchain: 12 }
+          - { compiler: clang-13,  cxxstd: '11,14,17,20',    os: ubuntu-22.04, gcc_toolchain: 12 }
+          - { compiler: clang-14,  cxxstd: '11,14,17,20',    os: ubuntu-22.04, gcc_toolchain: 12 }
+          - { compiler: clang-15,  cxxstd: '11,14,17,20',    os: ubuntu-22.04, gcc_toolchain: 12 }
           - { compiler: clang-16,  cxxstd: '11,14,17,20,2b', os: ubuntu-24.04 }
           # https://github.com/llvm/llvm-project/issues/59827: disabled 2b/23 for clang-17 with libstdc++13 in 24.04
           - { compiler: clang-17,  cxxstd: '11,14,17,20',    os: ubuntu-24.04 }
@@ -204,6 +204,7 @@ jobs:
             if [[ -z "${{matrix.install}}" ]]; then
                 pkgs="${{matrix.compiler}}"
                 pkgs="${pkgs/gcc-/g++-}"
+                [[ -z "${{matrix.gcc_toolchain}}" ]] || pkgs+=" g++-${{matrix.gcc_toolchain}}"
             else
                 pkgs="${{matrix.install}}"
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,10 @@ jobs:
           - { compiler: clang-10,  cxxstd: '11,14,17,20',    os: ubuntu-20.04 }
           - { compiler: clang-11,  cxxstd: '11,14,17,20',    os: ubuntu-20.04 }
           - { compiler: clang-12,  cxxstd: '11,14,17,20',    os: ubuntu-20.04 }
-          # Clang isn't compatible with libstdc++-13, so use the slightly older one
-          - { compiler: clang-13,  cxxstd: '11,14,17,20',    os: ubuntu-22.04, gcc_toolchain: 12 }
-          - { compiler: clang-14,  cxxstd: '11,14,17,20',    os: ubuntu-22.04, gcc_toolchain: 12 }
+          # Clang 13/14 isn't compatible with libstdc++-12
+          - { compiler: clang-13,  cxxstd: '11,14,17,20',    os: ubuntu-22.04, gcc_toolchain: 11 }
+          - { compiler: clang-14,  cxxstd: '11,14,17,20',    os: ubuntu-22.04, gcc_toolchain: 11 }
+          # Clang 15 isn't compatible with libstdc++-13
           - { compiler: clang-15,  cxxstd: '11,14,17,20',    os: ubuntu-22.04, gcc_toolchain: 12 }
           - { compiler: clang-16,  cxxstd: '11,14,17,20,2b', os: ubuntu-24.04 }
           # https://github.com/llvm/llvm-project/issues/59827: disabled 2b/23 for clang-17 with libstdc++13 in 24.04


### PR DESCRIPTION
Remove some redundancy:
```diff
- , install: 'clang-8 g++-7', gcc_toolchain: 7
+ , gcc_toolchain: 7
```

I did run into https://github.com/llvm/llvm-project/issues/55560 with Clang 13 & 14 and libstdc++ 12 & 13 so downgrading to 11.

I'm not fully sure about Clang 15 as [others use libstdc++ 11](https://github.com/boostorg/core/commit/7cbbb08e7be8114d4285e15634fc6b5ae23c17f6) with that too but I haven't seen issues with 12 so sticking to that for now.