### PR TITLE
LCOV_VERSION 2.3

### DIFF
--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -54,14 +54,58 @@ elif [[ "$coverage_action" == "collect" ]] || [[ "$coverage_action" == "upload" 
         GCOV=gcov-${ver}
     fi
 
-    # install the latest lcov we know works
-    : "${LCOV_VERSION:=v1.15}"
+    : "${LCOV_VERSION:=v2.3}" # Set default lcov version to install
 
-    if [[ "$LCOV_VERSION" =~ ^v[2-9] ]]; then
-        sudo apt-get -o Acquire::Retries="${NET_RETRY_COUNT:-3}" -y -q --no-install-suggests --no-install-recommends install libcapture-tiny-perl libdatetime-perl || true
-        LCOV_OPTIONS="${LCOV_OPTIONS} --ignore-errors unused"
-        LCOV_OPTIONS=$(echo ${LCOV_OPTIONS} | xargs echo)
+    : "${LCOV_BRANCH_COVERAGE:=1}" # Set default for branch coverage
+
+    : "${LCOV_IGNORE_ERRORS_LEVEL:="standard"}" # Set default error level. See below.
+
+    case $LCOV_IGNORE_ERRORS_LEVEL in
+    off)
+        # All errors are potentially fatal.
+        lcov_errors_to_ignore="";;
+    minimal)
+        # A suggested minimum even when trying to catch errors.
+        lcov_errors_to_ignore="unused";;
+    all)
+        # ignore all lcov errors
+        lcov_errors_to_ignore="annotate,branch,callback,category,child,count,corrupt,deprecated,empty,excessive,fork,format,inconsistent,internal,mismatch,missing,negative,package,parallel,path,range,source,unmapped,unsupported,unused,usage,utility,version";;
+    standard)
+        # A recommended default.
+        # The majority of boost libraries should pass.
+        # Notes about this setting:
+        # inconsistent - This error indicates that your coverage data is internally inconsistent: it makes two or more mutually exclusive claims.
+        # mismatch - Incorrect or inconsistent information found in coverage data and/or source code - for example, the source code contains overlapping exclusion directives.
+        # unused - The include/exclude/erase/substitute/omit pattern did not match any file pathnames.
+        #
+        lcov_errors_to_ignore="inconsistent,mismatch,unused";;
+    *)
+        echo "The value of LCOV_IGNORE_ERRORS_LEVEL ($LCOV_IGNORE_ERRORS_LEVEL) is not recognized."
+        echo "Please correct this. Exiting."
+        exit 1
+    esac
+
+    if [ -n "${lcov_errors_to_ignore}" ]; then
+        lcov_ignore_errors_flag="--ignore-errors ${lcov_errors_to_ignore}"
+    else
+        lcov_ignore_errors_flag=""
     fi
+
+    # The four LEVELs for error suppression above are meant to cover the most common cases.
+    # You can still select a fully custom option by using $LCOV_OPTIONS (in which case you may set $LCOV_IGNORE_ERRORS_LEVEL=off).
+
+    if [[ "$LCOV_VERSION" =~ ^v1 ]]; then
+        LCOV_OPTIONS="${LCOV_OPTIONS} --rc lcov_branch_coverage=${LCOV_BRANCH_COVERAGE}"
+
+    elif [[ "$LCOV_VERSION" =~ ^v[2-9] ]]; then
+        sudo apt-get -o Acquire::Retries="${NET_RETRY_COUNT:-3}" -y -q --no-install-suggests --no-install-recommends install \
+            libcapture-tiny-perl libdatetime-perl libjson-xs-perl || true
+            # libcpanel-json-xs-perl
+        LCOV_OPTIONS="${LCOV_OPTIONS} --rc branch_coverage=${LCOV_BRANCH_COVERAGE} ${lcov_ignore_errors_flag}"
+    fi
+
+    # Remove extra whitespace
+    LCOV_OPTIONS=$(echo ${LCOV_OPTIONS} | xargs echo)
 
     rm -rf /tmp/lcov
     cd /tmp
@@ -72,26 +116,25 @@ elif [[ "$coverage_action" == "collect" ]] || [[ "$coverage_action" == "upload" 
 
     # switch back to the original source code directory
     cd "$BOOST_CI_SRC_FOLDER"
-    : "${LCOV_BRANCH_COVERAGE:=1}" # Set default
 
     # coverage files are in ../../b2 from this location
-    lcov ${LCOV_OPTIONS} --rc lcov_branch_coverage="${LCOV_BRANCH_COVERAGE}" --gcov-tool="$GCOV" --directory "$BOOST_ROOT" --capture --output-file all.info
+    lcov ${LCOV_OPTIONS} --gcov-tool="$GCOV" --directory "$BOOST_ROOT" --capture --output-file all.info
     # dump a summary on the console
-    lcov --rc lcov_branch_coverage="${LCOV_BRANCH_COVERAGE}" --list all.info
+    lcov ${LCOV_OPTIONS} --list all.info
 
     # all.info contains all the coverage info for all projects - limit to ours
     # first we extract the interesting headers for our project then we use that list to extract the right things
     for f in $(for h in include/boost/*; do echo "$h"; done | cut -f2- -d/); do echo "*/$f*"; done > /tmp/interesting
     echo headers that matter:
     cat /tmp/interesting
-    xargs --verbose -L 999999 -a /tmp/interesting lcov ${LCOV_OPTIONS} --rc lcov_branch_coverage="${LCOV_BRANCH_COVERAGE}" --extract all.info "*/libs/$SELF/*" --output-file coverage.info
+    xargs --verbose -L 999999 -a /tmp/interesting lcov ${LCOV_OPTIONS} --extract all.info "*/libs/$SELF/*" --output-file coverage.info
 
     # dump a summary on the console - helps us identify problems in pathing
     # note this has test file coverage in it - if you do not want to count test
     # files against your coverage numbers then use a .codecov.yml file which
     # must be checked into the default branch (it is not read or used from a
     # pull request)
-    lcov --rc lcov_branch_coverage="${LCOV_BRANCH_COVERAGE}" --list coverage.info
+    lcov ${LCOV_OPTIONS} --list coverage.info
 
     if [[ "$coverage_action" == "upload" ]] && [[ "$BOOST_CI_CODECOV_IO_UPLOAD" != "skip" ]]; then
         #


### PR DESCRIPTION
Here is a small problem and a solution.

Issue:  
When running lcov this warning appears:

`lcov: WARNING: (deprecated) RC option 'lcov_branch_coverage' is deprecated.  Consider using 'branch_coverage'. instead.  (Backward-compatible support will be removed in the future.)`

A fix:  
Consolidate boost-ci scripts onto a newer lcov version.  Adjust the options flags, switching `lcov_branch_coverage` to `branch_coverage`.

As far as I am aware this update would be fine.  CI passes. @Flamefire did you have some experience that a newer `lcov` breaks compatibility, anywhere?  