### PR TITLE
Remove (wrong) workaround for codecov and enhance name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,7 @@ jobs:
           fail_ci_if_error: true
           disable_search: true
           files: coverage.info
-          name: ${{env.CODECOV_NAME}}
+          name: ${{env.CODECOV_NAME}} (POSIX)
           token: ${{secrets.CODECOV_TOKEN}}
           verbose: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,6 @@ jobs:
           name: ${{env.CODECOV_NAME}}
           token: ${{secrets.CODECOV_TOKEN}}
           verbose: true
-          working-directory: ${{github.workspace}}
 
       - name: Run coverity
         if: matrix.coverity && github.event_name == 'push' && (github.ref_name == 'develop' || github.ref_name == 'master')
@@ -353,7 +352,6 @@ jobs:
           name: ${{env.CODECOV_NAME}} (Windows)
           token: ${{secrets.CODECOV_TOKEN}}
           verbose: true
-          working-directory: ${{github.workspace}}
 
   MSYS2:
     defaults:


### PR DESCRIPTION
The issue with codecov wasn't the working-directory but the git safe-directory inside containers so this is not required.   
This should be [fixed](https://github.com/codecov/codecov-action/pull/1768) now

Also add `(POSIX)` suffix to the upload name similar to the `(WINDOWS)` suffix such that it is easier to distinguish on codecov.io.