### PR TITLE
Support B2_CI_VERSION="0" to indicate the old method

### DIFF
--- a/ci/appveyor/install.bat
+++ b/ci/appveyor/install.bat
@@ -1,7 +1,11 @@
 @ECHO ON
 
 REM Handle old appveyor configs
-IF NOT DEFINED B2_CI_VERSION (
+set res=F
+IF NOT DEFINED B2_CI_VERSION set res=T
+IF "%B2_CI_VERSION%"=="" set res=T
+IF "%B2_CI_VERSION%"=="0" set res=T
+if "%res%"=="T" (
 	IF DEFINED CXXFLAGS (
 	  SET B2_CXXFLAGS=%CXXFLAGS%
 	  SET CXXFLAGS=

--- a/ci/appveyor/mingw.bat
+++ b/ci/appveyor/mingw.bat
@@ -67,7 +67,12 @@ c:\msys64\usr\bin\env MSYSTEM=%UPPERFLAVOR% c:\msys64\usr\bin\bash -l -c ^
 ::
 :: Fix older build script definitions
 ::
-if NOT DEFINED B2_CI_VERSION (
+
+set res=F
+IF NOT DEFINED B2_CI_VERSION set res=T
+IF "%B2_CI_VERSION%"=="" set res=T
+IF "%B2_CI_VERSION%"=="0" set res=T
+if "%res%"=="T" (
   IF DEFINED CXXSTD (SET B2_CXXSTD=%CXXSTD%)
   IF DEFINED CXXSTD (SET CXXSTD=)
   :: Those 2 were broken

--- a/ci/build.bat
+++ b/ci/build.bat
@@ -1,8 +1,12 @@
 @ECHO OFF
 setlocal enabledelayedexpansion
 
-IF NOT DEFINED B2_CI_VERSION (
-    echo You need to set B2_CI_VERSION in your CI script
+set res=F
+IF NOT DEFINED B2_CI_VERSION set res=T
+IF "%B2_CI_VERSION%"=="" set res=T
+IF "%B2_CI_VERSION%"=="0" set res=T
+if "%res%"=="T" (
+    echo You need to set B2_CI_VERSION to 1 in your CI script
     exit /B 1
 )
 

--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -30,7 +30,7 @@ set -eux
 coverage_action=${1:-'<unset>'}
 
 if [[ "$coverage_action" == "setup" ]]; then
-    if [ -z "${B2_CI_VERSION:-}" ]; then
+    if [ -z "${B2_CI_VERSION:-}" ] || [ "${B2_CI_VERSION:-}" = "0" ]; then
         # Old CI version needs to use the prefixes
         export B2_VARIANT="variant=debug"
         export B2_CXXFLAGS="${B2_CXXFLAGS:+$B2_CXXFLAGS }cxxflags=-fkeep-static-functions cxxflags=--coverage"

--- a/ci/common_install.bat
+++ b/ci/common_install.bat
@@ -65,8 +65,10 @@ b2 -d0 headers
 ENDLOCAL
 
 if DEFINED B2_CI_VERSION (
+    if NOT "%B2_CI_VERSION%"=="0" (
 	REM Go back to lib folder to allow ci\build.bat to work
 	cd libs\%SELF%
+    )
 )
 
 EXIT /B %ERRORLEVEL%

--- a/ci/enforce.sh
+++ b/ci/enforce.sh
@@ -10,6 +10,21 @@
 
 set -e
 
+# Validate B2_CI_VERSION
+# Any of 0, unset, or empty, will count as the old method. 1 is the new method.
+# All boostorg libraries follow this pattern.
+# Beyond the following validation check, "1" is not being strictly enforced. Perhaps in the future it will be.
+# Currently all boost-ci logic compares B2_CI_VERSION against [0, unset, empty].
+
+if [ -z "${B2_CI_VERSION:-}" ] || [ "${B2_CI_VERSION:-}" = "0" ] || [ "${B2_CI_VERSION:-}" = "1" ]; then
+    # Those are all accepted values of B2_CI_VERSION. Proceeding.
+    true
+else
+    echo "B2_CI_VERSION must be 0, 1, unset, or empty."
+    echo "Please correct this. Exiting."
+    exit 1
+fi
+
 function get_python_executable {
     if command -v python &> /dev/null; then
         echo "python"
@@ -67,7 +82,7 @@ fi
 
 # Build cmdline arguments for B2 in the array B2_ARGS to preserve quotes
 
-if [ -n "${B2_CI_VERSION:-}" ]; then # Set B2_CI_VERSION to opt in to new features
+if [ -n "${B2_CI_VERSION:-}" ] && [ ! "${B2_CI_VERSION:-}" = "0" ]; then # Set B2_CI_VERSION to opt in to new features
   function append_b2_args {
       # Generate multiple "option=value" entries from the value of an environment variable
       # Handles correct splitting and quoting


### PR DESCRIPTION
A few boost libraries still depend on the old boost-ci method which corresponds to an unset B2_CI_VERSION.
What we'd like to do is recognize B2_CI_VERSION="0" as another way to positively select the earlier method.
This is a phased approach.  After all libraries have been fixed, it would then be possible to switch boost-ci to  B2_CI_VERSION="1" functionality more often.

