### PR TITLE
Use Github output file for printing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
           if not coverity_scan_token:
               filtered = [e for e in filtered if not e.get("coverity") == "yes"]
 
-          with open(os.environ["GITHUB_OUTPUT"]) as f:
+          with open(os.environ["GITHUB_OUTPUT"], mode='a') as f:
               f.write(f"matrix={json.dumps({'include': filtered})}\n")
         shell: python
         env:


### PR DESCRIPTION
The `set-output` is deprecated and may stop working anytime now.

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#patching-your-actions-and-workflows

Note: Made the change in the GitHub editor but should be fine