### PR TITLE
Refer to develop branch as the main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Here are all the steps you need to take as a Boost repository maintainer to enab
     * Note that those include CMake tests, so see the [CMake docs](CMake.md#ci-tests) for details and requirements.
     * For some features to work the `B2_CI_VERSION` variable set in those configs is relevant as without that a legacy codepath will be used to ensure compatibility with old CI configs if that is unset or set to zero.
 1. Copy the `.drone.star` file and optionally the `.drone` directory from this repository to the top level of your repository.
-1. Copy the `.codecov.yml` file from this repository to the top level of your repository and edit if required. Note that **only** the file in the default branch (usually `master`) is considered!
+1. Copy the `.codecov.yml` file from this repository to the top level of your repository and edit if required. Note that **only** the file in the default branch (usually `master`/`main`, or `develop` for most Boost libraries) is considered!
 1. Copy the `LICENSE` file from this repository to the top level of your repository.  This adds the `BSL-1.0` designation to your repository on github.
 1. [optional] Copy the `README.template.md` file from this repository to the top level `README.md` of your repository.  If you already have a README.md then you can take what you need from the template version to improve it, if desired.  Otherwise, you will need to customize README.md for your repository.  One useful step is to fixup the repository name using the command `sed -i 's/template/<myrepositoryname>/g' README.md`, and then update the first line description.
 1. In Appveyor, add a project for your fork of the repository.  No customization is needed.


### PR DESCRIPTION
That's what usually is the default branch for Boost libs