### PR TITLE
Remove msvc-14.0 and msvc.14.2 jobs as windows-2019 GHA runner was removed

### DIFF
--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -419,8 +419,6 @@ jobs:
           import json, os
 
           original = [
-            {"toolset": "msvc-14.0", "cxxstd": "14,latest",       "address-model": "32,64", "os": "windows-2019"},
-            {"toolset": "msvc-14.2", "cxxstd": "14,17,20",        "address-model": "32,64", "os": "windows-2019"},
             {"toolset": "msvc-14.3", "cxxstd": "14,17,20,latest", "address-model": "32,64", "os": "windows-2022"},
             {"name": "Collect coverage", "coverage": "yes",
              "toolset": "msvc-14.3", "cxxstd": "latest",          "address-model": "64",    "os": "windows-2025"},


### PR DESCRIPTION
This fixes #286

windows-2022 and 2025 runners only have MSVC2013 and MSVC2022, we don't test MSVC2013 as it's EOL