### PR TITLE
Pass B2_TOOLSET to install.bat

### DIFF
--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -495,6 +495,8 @@ jobs:
 
       - name: Setup Boost
         run: ci\github\install.bat
+        env:
+          B2_TOOLSET: ${{matrix.toolset}}
 
       - name: Run tests
         if: '!matrix.coverage'


### PR DESCRIPTION
This is required to test #288 and previously wasn't required.

Might cause failures because we had code testing for clang-win and gcc before, so let's see how #288 looks after merging this