### PR TITLE
Add option to enable coverage for PRs

### DIFF
--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -51,6 +51,11 @@ on:
         required: false
         type: boolean
         default: true
+      enable_pr_coverage:
+        description: "When enabled, coverage will be collected even without a $CODECOV_TOKEN, e.g for PRs where it  usually is not available. Enabled by default."
+        required: false
+        type: boolean
+        default: true
       enable_sanitizers:
         description: "When enabled, sanitizer (ASAN, UBSAN) jobs will be added. By default, sanitizer jobs are enabled."
         required: false
@@ -212,7 +217,7 @@ jobs:
               filtered = filter_multi_valued(filtered, 'address-model', '32')
           if not is_true('ENABLE_SANITIZERS'):
               filtered = filter_yes_values(filtered, 'sanitize')
-          if not os.environ.get('CODECOV_TOKEN'):
+          if not os.environ.get('CODECOV_TOKEN') and '${{inputs.enable_pr_coverage}}' != 'true':
               filtered = filter_yes_values(filtered, 'coverage')
           if not os.environ.get('COVERITY_SCAN_TOKEN'):
               filtered = filter_yes_values(filtered, 'coverity')


### PR DESCRIPTION
For PRs from third-parties secrets are not available so `$CODECOV_TOKEN` will be empty and PRs won't receive coverage reports and statistics.

Restore the old behavior of always (trying) uploading coverage and add an option to disable it.

Alternative: Add an option `enable_coverage` as the only way to toggle coverage jobs

Test run: https://github.com/boostorg/boost-ci/actions/runs/16775039390

@jeking3 I used the input directly instead of going through an env variable as it requires less changes/code.   
Should we do that for the other inputs too? IMO having a clear distinction of env variables and job inputs makes it easier to reason. Or was there a specific reason to use those env variables?