### PR TITLE
Remove macos-13

### DIFF
--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -167,7 +167,6 @@ jobs:
               {"name": "Clang w/ sanitizers", "sanitize": "yes", "stdlib": "libc++",
                "compiler": "clang-12",  "cxxstd": "11,14,17,20",       "os": "ubuntu-latest", "container": "ubuntu:20.04"}, 
             # MacOS
-              {"compiler": "clang",     "cxxstd": "11,14,17,20,2b",    "os": "macos-13"},
               {"name": "sanitize-clang-macos", "sanitize": "yes",
                "compiler": "clang",     "cxxstd": "11,14,17,20,2b",    "os": "macos-14"},
               {"compiler": "clang-16",  "cxxstd": "11,14,17,20,2b",    "os": "macos-15"},


### PR DESCRIPTION
Runner will be removed by 4th Dec 2025 and starts with brownouts in Nov, see: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down

Remove from joblist