### PR TITLE
Drone: hosted keyserver

### DIFF
--- a/ci/drone/linux-cxx-install.sh
+++ b/ci/drone/linux-cxx-install.sh
@@ -37,7 +37,9 @@ function add_repository_toolchain {
         echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu ${VERSION_CODENAME} main" 
         echo "# deb-src http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu ${VERSION_CODENAME} main"
     } > "/etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-${VERSION_CODENAME}.list"
-    curl -sSL --retry "${NET_RETRY_COUNT:-5}" 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F' | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/toolchain-r.gpg
+    keyserver="keyserver.boost.org"
+    echo "Downloading toolchain gpg key via ${keyserver}"
+    curl -sSL --retry "${NET_RETRY_COUNT:-5}" "http://${keyserver}/pks/lookup?op=get&search=0x1E9377A2BA9EF27F" | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/toolchain-r.gpg
 }
 
 echo ">>>>> APT: REPOSITORIES..."


### PR DESCRIPTION
Just set up a `keyserver.boost.org` that's a Fastly CDN mirror of `keyserver.ubuntu.com`.  Try it on Drone.  
Why...
because sometimes `keyserver.ubuntu.com` times out.


