### PR TITLE
Reusable: Add option to choose minimal CMake version to use

### DIFF
--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -718,7 +718,7 @@ jobs:
           - { os: ubuntu-latest, build_shared: OFF, build_type: Debug, generator: 'Unix Makefiles' }
           - { os: windows-2025,  build_shared: ON,  build_type: Debug, generator: 'Visual Studio 17 2022' }
           - { os: windows-2025,  build_shared: OFF, build_type: Debug, generator: 'Visual Studio 17 2022' }
-          - { name: "Linux CMake", cmake_version: '${{inputs.min_cmake_version}}',
+          - { name: "Min. CMake", cmake_version: '${{inputs.min_cmake_version}}',
               os: ubuntu-latest, build_shared: ON,  build_type: Debug, generator: 'Unix Makefiles' }
 
     steps:
@@ -740,6 +740,7 @@ jobs:
         if: matrix.cmake_version && steps.cache-cmake.outputs.cache-hit != 'true'
         run: |
             version=${{matrix.cmake_version}}
+            [[ ${version} =~ [0-9]+\.[0-9]+\.[0-9]+ ]] || version+=".0"
             filename="cmake-$version.tar.gz"
             cd "$(mktemp -d)"
             wget https://cmake.org/files/v${version%.*}/$filename


### PR DESCRIPTION
This adds a new CMake job to the reusable workflow that builds with a specific CMake version in addition to the "latest".

"latest" in this case is the default CMake version in the ubuntu-latest GHA runner.

The new job is supposed to test the CMake version a library is supposed to support. This can be set by the new input parameter  `min_cmake_version` which defaults to 3.16(.0). The patch version can be omitted in which case ".0" is appended

This CMake version is downloaded and build from source (takes ~4.5min) and then cached (restored instantly, cache size ~17MB)

The [alternative approach](https://github.com/boostorg/boost-ci/actions/runs/18875989927/job/53865801122) of using an Ubuntu 20.04 container takes ~26s to install required packages while this takes ~20s for required packages and virtually no time to restore the CMake cache.   
And this approach is more flexible for individual library authors

Test job: https://github.com/boostorg/boost-ci/actions/runs/18877843599/job/53872379415