### PR TITLE
Add Windows ARM Configuration

### DIFF
--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -462,6 +462,7 @@ jobs:
 
           all_jobs = [
             {"toolset": "msvc-14.3", "cxxstd": "14,17,20,latest", "address-model": "32,64", "os": "windows-2022"},
+            {"toolset": "msvc-14.3", "cxxstd": "14,17,20,latest", "address-model": "64", "os": "windows-11-arm"},
             {"name": "Collect coverage", "coverage": "yes",
              "toolset": "msvc-14.3", "cxxstd": "latest",          "address-model": "64",    "os": "windows-2025"},
             {"toolset": "clang-win", "cxxstd": "14,17,latest",    "address-model": "32,64", "os": "windows-2025"},


### PR DESCRIPTION
Windows on ARM is now available through Github Actions. There's additional ARM configurations available for linux if you're interested: https://github.com/actions/partner-runner-images/tree/main.  