### PR TITLE
code-coverage

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,113 @@
+#
+# Copyright (c) 2026 Sam Darwin
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+
+# Instructions
+#
+# After running this workflow successfully, go to https://github.com/ORGANIZATION/REPO/settings/pages
+# and enable github pages on the code-coverage branch.  
+# The pages will be hosted at https://ORGANIZATION.github.io/REPO
+#
+
+name: Code Coverage
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+    paths:
+      - 'src/**'
+      - 'include/**'
+
+env:
+  GIT_FETCH_JOBS: 8
+  NET_RETRY_COUNT: 5
+
+jobs:
+  build:
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs-on: "ubuntu-24.04"
+            name: Coverage
+            cxxstd: "20"
+            gcovr_script: './ci-automation/scripts/lcov-jenkins-gcc-13.sh --only-gcovr'
+
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Check for code-coverage Branch
+        run: |
+            set -xe
+            git config --global user.name cppalliance-bot
+            git config --global user.email cppalliance-bot@example.com
+            git fetch origin
+            if git branch -r | grep origin/code-coverage; then
+                echo "The code-coverage branch exists. Continuing."
+            else
+                echo "The code-coverage branch does not exist. Creating it."
+                git checkout -b code-coverage
+                git push origin code-coverage
+                git checkout $GITHUB_REF_NAME
+            fi
+
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install Python packages
+        run: pip install gcovr
+
+      - name: Checkout ci-automation
+        uses: actions/checkout@v6
+        with:
+          repository: cppalliance/ci-automation
+          path: ci-automation
+
+      - name: Build and run tests & collect coverage data
+        run: |
+            set -xe
+            ls -al
+            export ORGANIZATION=${GITHUB_REPOSITORY_OWNER}
+            export REPONAME=$(basename ${GITHUB_REPOSITORY})
+            export B2_CXXSTD=${{matrix.cxxstd}}
+            ${{matrix.gcovr_script}}
+
+      - name: Checkout GitHub pages branch
+        uses: actions/checkout@v6
+        with:
+          ref: code-coverage
+          path: gh_pages_dir
+
+      - name: Copy gcovr results
+        run: |
+            set -xe
+            pwd
+            ls -al
+            touch gh_pages_dir/.nojekyll # Prevent GH pages from treating these files as Jekyll pages.
+            mkdir -p gh_pages_dir/develop
+            mkdir -p gh_pages_dir/master
+            cp -rp gcovr gh_pages_dir/${GITHUB_REF_NAME}/
+            echo -e "<html>\n<head>\n</head>\n<body>\n<a href=develop/index.html>develop</a><br>\n<a href=master/index.html>master</a><br>\n</body>\n</html>\n" > gh_pages_dir/index.html
+            # In the future: echo -e "<html>\n<head>\n</head>\n<body>\n<a href=gcovr/index.html>gcovr</a><br>\n</body>\n</html>\n" > gh_pages_dir/develop/index.html
+            echo -e "<html>\n<head>\n<meta http-equiv=\"refresh\" content=\"0; url=./gcovr/index.html\">\n</head>\n<body>\n</body>\n</html>\n" > gh_pages_dir/develop/index.html
+            cp gh_pages_dir/develop/index.html gh_pages_dir/master/index.html
+            cd gh_pages_dir
+            git add .
+            git commit --amend -m code-coverage
+            git push -f origin code-coverage

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Multiple CI configs contain jobs collecting code coverage data.
 E.g. Github Actions and Drone CI for Linux and Appveyor for Windows.
 Especially the latter allows to collect coverage data for Windows-only codeparts or code using e.g. `wchar_t` which is different on Windows than on other platforms.
 
+Besides using Codecov, it's also possible to generate coverage reports with [GitHub Actions + GitHub Pages](docs/code-coverage.md).
+
 ### Exclusion of coverage data
 
 If you want to exclude parts of your code from coverage analysis you can use the LCOV comments/macros:

--- a/docs/code-coverage.md
+++ b/docs/code-coverage.md
@@ -1,0 +1,45 @@
+
+## Code Coverage with Github Actions and Github Pages
+
+An exciting new method to generate gcovr coverage reports without relying on Codecov.
+
+![Screenshot of gcovr report](https://dl.cpp.al/misc/gcovr-example.png?)
+
+## Instructions
+
+Copy the file `.github/workflows/code-coverage.yml` from boost-ci into your Boost library repository.
+
+Run the workflow at least once. It will create a code-coverage branch to store reports.
+
+Next, enable GitHub Pages. Go to https://github.com/ORGANIZATION/REPO/settings/pages and enable the new branch.  
+
+The coverage will be hosted at https://ORGANIZATION.github.io/REPO
+
+### Adding Coverage Badges to Your Project
+
+To display coverage badges in your repository's README, use the following Markdown snippets. Replace `{organization}` with the github organization, `{branch}` with the branch name (e.g. `develop`, `master`) and `{repo}` with your repository name (e.g. `json`, `capy`).
+
+**Available badges:**
+
+| Badge | URL |
+|-------|-----|
+| Lines | `https://{organization}.github.io/{repo}/{branch}/gcovr/badges/coverage-lines.svg` |
+| Functions | `https://{organization}.github.io/{repo}/{branch}/gcovr/badges/coverage-functions.svg` |
+| Branches | `https://{organization}.github.io/{repo}/{branch}/gcovr/badges/coverage-branches.svg` |
+
+**Markdown to copy into your README:**
+
+```markdown
+[![Lines](https://{organization}.github.io/{repo}/{branch}/gcovr/badges/coverage-lines.svg)](https://{organization}.github.io/{repo}/{branch}/gcovr/index.html)
+[![Functions](https://{organization}.github.io/{repo}/{branch}/gcovr/badges/coverage-functions.svg)](https://{organization}.github.io/{repo}/{branch}/gcovr/index.html)
+[![Branches](https://{organization}.github.io/{repo}/{branch}/gcovr/badges/coverage-branches.svg)](https://{organization}.github.io/{repo}/{branch}/gcovr/index.html)
+```
+
+For example, boostorg/json on the `develop` branch:
+
+```markdown
+[![Lines](https://boostorg.github.io/json/develop/gcovr/badges/coverage-lines.svg)](https://boostorg.github.io/json/develop/gcovr/index.html)
+[![Functions](https://boostorg.github.io/json/develop/gcovr/badges/coverage-functions.svg)](https://boostorg.github.io/json/develop/gcovr/index.html)
+[![Branches](https://boostorg.github.io/json/develop/gcovr/badges/coverage-branches.svg)](https://boostorg.github.io/json/develop/gcovr/index.html)
+
+


### PR DESCRIPTION
Generate code coverage reports with the toolset of gcovr, GitHub Actions, and GitHub Pages. 
@Flamefire let me know what you think.