### PR TITLE
Create empty `code-coverage` branch and allow custom commit message

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2026 Sam Darwin
+# Copyright (c) 2026 Alexander Grund
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -29,7 +30,6 @@ env:
   GIT_FETCH_JOBS: 8
   NET_RETRY_COUNT: 5
   # Commit title of the automatically created commits
-  # Will amend the last commit when it has the same title
   GCOVR_COMMIT_MSG: "Update coverage data"
 
 jobs:
@@ -115,10 +115,5 @@ jobs:
             cp gh_pages_dir/develop/index.html gh_pages_dir/master/index.html
             cd gh_pages_dir
             git add .
-            # Amend if current HEAD is (still) a coverage update
-            if [[ "$(git show --format="%s" --no-patch)" == "$GCOVR_COMMIT_MSG" ]]; then
-                git commit --amend --no-edit
-            else
-                git commit -m "$GCOVR_COMMIT_MSG"
-            fi
+            git commit --amend -m "$GCOVR_COMMIT_MSG"
             git push -f origin code-coverage

--- a/docs/code-coverage.md
+++ b/docs/code-coverage.md
@@ -11,6 +11,8 @@ Copy the file `.github/workflows/code-coverage.yml` from boost-ci into your Boos
 
 Run the workflow at least once, which can be done [manually](https://docs.github.com/actions/how-tos/manage-workflow-runs/manually-run-a-workflow).
 This will create a branch called "code-coverage" to store reports.
+On this branch a single commit will be created and updated (amended) with every run of the workflow to reduce the size of the repository.
+Hence it is not intended for other commits as the last one will always be changed.
 
 Next, enable GitHub Pages. Go to https://github.com/ORGANIZATION/REPO/settings/pages and enable the new branch.  
 


### PR DESCRIPTION
Use `--orphan` instead of using the current branchs content and history. Set the commit title in an environment variable ~and only amend commits with that title to allow for custom commits.~

See [recent discussion](https://github.com/boostorg/boost-ci/pull/316#issuecomment-3899434561)


Before merge I'll delete the branch here to test it