### PR TITLE
Add LCOV_BRANCH_COVERAGE to code-coverage.yml

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -31,6 +31,7 @@ env:
   NET_RETRY_COUNT: 5
   # Commit title of the automatically created commits
   GCOVR_COMMIT_MSG: "Update coverage data"
+  LCOV_BRANCH_COVERAGE: 1
 
 jobs:
   build:


### PR DESCRIPTION
Explicitely set branch coverage in code coverage workflow to show how/where to disable it

@sdarwin Or shall we have "false"/0 as the default?