### PR TITLE
code-coverage.yml: remove large files

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -122,6 +122,9 @@ jobs:
             mkdir -p gh_pages_dir/master
             rm -rf "gh_pages_dir/${GITHUB_REF_NAME}/gcovr"
             cp -rp gcovr "gh_pages_dir/${GITHUB_REF_NAME}/"
+            # Large files cannot be uploaded:
+            rm -f gh_pages_dir/${GITHUB_REF_NAME}/gcovr/coverage-raw.json
+            rm -f gh_pages_dir/${GITHUB_REF_NAME}/gcovr/coverage-fixed.json
             echo -e "<html>\n<head>\n</head>\n<body>\n<a href=\"develop/index.html\">develop</a><br>\n<a href=\"master/index.html\">master</a><br>\n</body>\n</html>\n" > gh_pages_dir/index.html
             # In the future: echo -e "<html>\n<head>\n</head>\n<body>\n<a href=gcovr/index.html>gcovr</a><br>\n</body>\n</html>\n" > gh_pages_dir/develop/index.html
             echo -e "<html>\n<head>\n<meta http-equiv=\"refresh\" content=\"0; url=./gcovr/index.html\">\n</head>\n<body>\n</body>\n</html>\n" > gh_pages_dir/develop/index.html


### PR DESCRIPTION
When testing `boostorg/container` with code-coverage.yml, coverage-fixed.json and coverage-raw.json failed to upload, which crashed the CI process.  See attached fix.  


