### PR TITLE
Add test for CMake config files installed by B2

### DIFF
--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -868,6 +868,11 @@ jobs:
             cd "$BOOST_ROOT"
             ./bootstrap.sh
             ./b2 cxxstd="20" --prefix="$BCM_INSTALL_PATH" -j$B2_JOBS install
-
+            echo "BOOST_ROOT_WIN=$(cygpath -w "$BOOST_ROOT")" >> $GITHUB_ENV
+      - name: Install with b2 (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: .\b2 cxxstd=20 --prefix="$env:BCM_INSTALL_PATH" -j$env:B2_JOBS install
+        working-directory: ${{env.BOOST_ROOT_WIN}}
       - name: Run CMake install tests w/ B2 installed library
         run: ci/test_installed_cmake_config.sh

--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -859,20 +859,31 @@ jobs:
             cmake --build . --target install --config ${{matrix.build_type}} -j$B2_JOBS
 
       - name: Run CMake install tests
-        run: ci/test_installed_cmake_config.sh
-
-      - name: Install with b2
+        run: |
+          ci/test_installed_cmake_config.sh
+      - name: Prepare for B2 installation
         run: |
             BCM_INSTALL_PATH+=_b2
-            echo "BCM_INSTALL_PATH=$BCM_INSTALL_PATH" >> "$GITHUB_ENV"
-            cd "$BOOST_ROOT"
+            if [[ "$RUNNER_OS" == "Windows" ]]; then
+              # Convert path for use in pwsh
+              echo "BCM_INSTALL_PATH=$(cygpath -w "$BCM_INSTALL_PATH")" >> $GITHUB_ENV
+              echo "BOOST_ROOT_WIN=$(cygpath -w "$BOOST_ROOT")" >> $GITHUB_ENV
+            else
+              echo "BCM_INSTALL_PATH=${BCM_INSTALL_PATH}" >> "$GITHUB_ENV"
+            fi
+
+      - name: Install with b2 (Posix)
+        if: runner.os != 'Windows'
+        run: |
             ./bootstrap.sh
             ./b2 cxxstd="20" --prefix="$BCM_INSTALL_PATH" -j$B2_JOBS install
-            echo "BOOST_ROOT_WIN=$(cygpath -w "$BOOST_ROOT")" >> $GITHUB_ENV
+        working-directory: ${{env.BOOST_ROOT}}
       - name: Install with b2 (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
-        run: .\b2 cxxstd=20 --prefix="$env:BCM_INSTALL_PATH" -j$env:B2_JOBS install
+        run: |
+          .\bootstrap.bat
+          .\b2 cxxstd=20 --prefix="$env:BCM_INSTALL_PATH" -j$env:B2_JOBS install
         working-directory: ${{env.BOOST_ROOT_WIN}}
       - name: Run CMake install tests w/ B2 installed library
         run: ci/test_installed_cmake_config.sh

--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -848,25 +848,41 @@ jobs:
       - name: Install Library
         run: |
             BCM_INSTALL_PATH=/tmp/boost_install
+            # Variables expected by test_installed_cmake_config.sh
             echo "BCM_INSTALL_PATH=$BCM_INSTALL_PATH" >> "$GITHUB_ENV"
+            echo "CI_GENERATOR=${{matrix.generator}}" >> "$GITHUB_ENV"
+            echo "CI_BUILD_TYPE=${{matrix.build_type}}" >> "$GITHUB_ENV"
+            echo "CI_BUILD_SHARED=${{matrix.build_shared}}" >> "$GITHUB_ENV"
             cd "$BOOST_ROOT"
             mkdir __build_cmake_install_test__ && cd __build_cmake_install_test__
             cmake -G "${{matrix.generator}}" -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBOOST_INCLUDE_LIBRARIES=$SELF -DBUILD_SHARED_LIBS=${{matrix.build_shared}} -DCMAKE_INSTALL_PREFIX="$BCM_INSTALL_PATH" -DBoost_VERBOSE=ON -DBoost_DEBUG=ON ..
             cmake --build . --target install --config ${{matrix.build_type}} -j$B2_JOBS
+
       - name: Run CMake install tests
+        run: ci/test_installed_cmake_config.sh
+
+      - name: Install with b2
         run: |
-            cmake_test_folder="$BOOST_ROOT/libs/$SELF/test/cmake_test" # New unified folder
-            [ -d "$cmake_test_folder" ] || cmake_test_folder="$BOOST_ROOT/libs/$SELF/test/cmake_install_test"
-            cd "$cmake_test_folder"
-            mkdir __build_cmake_install_test__ && cd __build_cmake_install_test__
-            cmake -G "${{matrix.generator}}" -DBOOST_CI_INSTALL_TEST=ON -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBUILD_SHARED_LIBS=${{matrix.build_shared}} -DCMAKE_PREFIX_PATH="$BCM_INSTALL_PATH" ..
-            cmake --build . --config ${{matrix.build_type}} -j$B2_JOBS
-            if [[ "${{matrix.build_shared}}" == "ON" ]]; then
-                # Make sure shared libs can be found at runtime
-                if [ "$RUNNER_OS" == "Windows" ]; then
-                    export PATH="$BCM_INSTALL_PATH/bin:$PATH"
-                else
-                    export LD_LIBRARY_PATH="$BCM_INSTALL_PATH/lib:$LD_LIBRARY_PATH"
-                fi
+            BCM_INSTALL_PATH+=_b2
+            echo "BCM_INSTALL_PATH=$BCM_INSTALL_PATH" >> "$GITHUB_ENV"
+            cd "$BOOST_ROOT"
+            if [[ "${{matrix.build_type}}" == "Debug" ]]; then
+              variant=debug
+            else
+              variant=release
             fi
-            ctest --output-on-failure --build-config ${{matrix.build_type}}
+            if [[ "${{matrix.build_shared}}" == "ON" ]]; then
+              link=shared
+            else
+              link=static
+            fi
+            if [[ "$RUNNER_OS" == "Windows" ]]; then
+              toolset="msvc-14.3"
+            else
+              toolset="gcc"
+            fi
+            ./bootstrap.sh
+            ./b2 toolset="$toolset" variant="$variant" link="$link" cxxstd="20" --prefix="$BCM_INSTALL_PATH" -j$B2_JOBS install
+
+      - name: Run CMake install tests w/ B2 installed library
+        run: ci/test_installed_cmake_config.sh

--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -866,23 +866,8 @@ jobs:
             BCM_INSTALL_PATH+=_b2
             echo "BCM_INSTALL_PATH=$BCM_INSTALL_PATH" >> "$GITHUB_ENV"
             cd "$BOOST_ROOT"
-            if [[ "${{matrix.build_type}}" == "Debug" ]]; then
-              variant=debug
-            else
-              variant=release
-            fi
-            if [[ "${{matrix.build_shared}}" == "ON" ]]; then
-              link=shared
-            else
-              link=static
-            fi
-            if [[ "$RUNNER_OS" == "Windows" ]]; then
-              toolset="msvc-14.3"
-            else
-              toolset="gcc"
-            fi
             ./bootstrap.sh
-            ./b2 toolset="$toolset" variant="$variant" link="$link" cxxstd="20" --prefix="$BCM_INSTALL_PATH" -j$B2_JOBS install
+            ./b2 cxxstd="20" --prefix="$BCM_INSTALL_PATH" -j$B2_JOBS install
 
       - name: Run CMake install tests w/ B2 installed library
         run: ci/test_installed_cmake_config.sh

--- a/ci/test_installed_cmake_config.sh
+++ b/ci/test_installed_cmake_config.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Copyright 2020-2021 Peter Dimov
+# Copyright 2021 Andrey Semashev
+# Copyright 2021-2026 Alexander Grund
+# Copyright 2022-2025 James E. King III
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+#      http://www.boost.org/LICENSE_1_0.txt)
+
+# Test the installed CMake config files by building and running the CMake install test.
+# Environment variables:
+# - SELF: the name of the library being tested
+# - BOOST_ROOT: root of the boost source tree
+# - BCM_INSTALL_PATH: path where the CMake config files are installed
+# - B2_JOBS: number of parallel jobs to use for building
+# - CI_GENERATOR: the CMake generator to use (e.g. "Ninja" or "Unix Makefiles")
+# - CI_BUILD_TYPE: the build type to use (e.g. "Debug" or "Release")
+# - CI_BUILD_SHARED: whether to build shared libraries (ON or OFF)
+# - RUNNER_OS: the operating system (e.g. "Windows", "Linux", "macOS")
+
+set -eux
+
+cmake_test_folder="$BOOST_ROOT/libs/$SELF/test/cmake_test" # New unified folder
+[ -d "$cmake_test_folder" ] || cmake_test_folder="$BOOST_ROOT/libs/$SELF/test/cmake_install_test"
+cd "$cmake_test_folder"
+
+rm -rf __build_cmake_install_test__
+mkdir __build_cmake_install_test__ && cd __build_cmake_install_test__
+
+if [[ $CI_BUILD_SHARED == "ON" ]]; then
+    Boost_USE_STATIC_LIBS=OFF
+else
+    Boost_USE_STATIC_LIBS=ON
+fi
+
+unset BOOST_ROOT # Make sure CMake finds the installed config, not the source tree
+cmake -DBOOST_CI_INSTALL_TEST=ON \
+    -G "$CI_GENERATOR" \
+    -DBUILD_SHARED_LIBS="$CI_BUILD_SHARED" \
+    -DBoost_USE_STATIC_LIBS="$Boost_USE_STATIC_LIBS" \
+    -DCMAKE_BUILD_TYPE="$CI_BUILD_TYPE" \
+    -DCMAKE_PREFIX_PATH="$BCM_INSTALL_PATH" \
+    -DCMAKE_VERBOSE_MAKEFILE=ON ..
+
+cmake --build . --config "$CI_BUILD_TYPE" -j "$B2_JOBS"
+if [[ "$CI_BUILD_SHARED" == "ON" ]]; then
+    # Make sure shared libs can be found at runtime
+    if [ "$RUNNER_OS" == "Windows" ]; then
+        export PATH="$BCM_INSTALL_PATH/bin:$PATH"
+    else
+        export LD_LIBRARY_PATH="$BCM_INSTALL_PATH/lib:${LD_LIBRARY_PATH:-}"
+    fi
+fi
+ctest --output-on-failure --build-config "$CI_BUILD_TYPE"

--- a/ci/test_installed_cmake_config.sh
+++ b/ci/test_installed_cmake_config.sh
@@ -38,12 +38,10 @@ cmake -DBOOST_CI_INSTALL_TEST=ON \
     -DCMAKE_VERBOSE_MAKEFILE=ON ..
 
 cmake --build . --config "$CI_BUILD_TYPE" -j "$B2_JOBS"
-if [[ "$CI_BUILD_SHARED" == "ON" ]]; then
-    # Make sure shared libs can be found at runtime
-    if [ "$RUNNER_OS" == "Windows" ]; then
-        export PATH="$BCM_INSTALL_PATH/bin:$PATH"
-    else
-        export LD_LIBRARY_PATH="$BCM_INSTALL_PATH/lib:${LD_LIBRARY_PATH:-}"
-    fi
+# Make sure shared libs can be found at runtime
+if [ "$RUNNER_OS" == "Windows" ]; then
+    export PATH="$BCM_INSTALL_PATH/bin:$PATH"
+else
+    export LD_LIBRARY_PATH="$BCM_INSTALL_PATH/lib:${LD_LIBRARY_PATH:-}"
 fi
 ctest --output-on-failure --build-config "$CI_BUILD_TYPE"

--- a/ci/test_installed_cmake_config.sh
+++ b/ci/test_installed_cmake_config.sh
@@ -29,17 +29,10 @@ cd "$cmake_test_folder"
 rm -rf __build_cmake_install_test__
 mkdir __build_cmake_install_test__ && cd __build_cmake_install_test__
 
-if [[ $CI_BUILD_SHARED == "ON" ]]; then
-    Boost_USE_STATIC_LIBS=OFF
-else
-    Boost_USE_STATIC_LIBS=ON
-fi
-
 unset BOOST_ROOT # Make sure CMake finds the installed config, not the source tree
 cmake -DBOOST_CI_INSTALL_TEST=ON \
     -G "$CI_GENERATOR" \
     -DBUILD_SHARED_LIBS="$CI_BUILD_SHARED" \
-    -DBoost_USE_STATIC_LIBS="$Boost_USE_STATIC_LIBS" \
     -DCMAKE_BUILD_TYPE="$CI_BUILD_TYPE" \
     -DCMAKE_PREFIX_PATH="$BCM_INSTALL_PATH" \
     -DCMAKE_VERBOSE_MAKEFILE=ON ..

--- a/test/cmake_test/CMakeLists.txt
+++ b/test/cmake_test/CMakeLists.txt
@@ -9,7 +9,7 @@ project(cmake_subdir_test LANGUAGES CXX)
 # Those 2 should work the same
 # while using find_package for the installed Boost avoids the need to manually specify dependencies
 if(BOOST_CI_INSTALL_TEST)
-    find_package(boost_boost_ci REQUIRED)
+    find_package(Boost COMPONENTS boost_ci REQUIRED)
 else()
     add_subdirectory(../.. boostorg/boost-ci)
 


### PR DESCRIPTION
I factored out the test script to consume the library with CMake.
This is then used in 2 steps:
- On the library installed with CMake (as before)
- **new:** Same but installed with B2 

Test jobs passed:
https://github.com/boostorg/boost-ci/actions/runs/25279016552/job/74113264712
https://github.com/boostorg/boost-ci/actions/runs/25279016552/job/74113264736