### PR TITLE
Align B2 and CMake target names

### DIFF
--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -298,13 +298,22 @@ jobs:
             if [ -n "${{matrix.container}}" ] && [ -f "/etc/debian_version" ]; then
                 apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
                 apt-get -o Acquire::Retries=$NET_RETRY_COUNT -y -q --no-install-suggests --no-install-recommends install sudo software-properties-common curl
-                # Need (newer) git, and the older Ubuntu container may require requesting the key manually using port 80
-                key_server="keyserver.boost.org"
-                echo "Downloading key from $key_server"
-                curl -sSL --retry ${NET_RETRY_COUNT:-5} "https://$key_server/pks/lookup?op=get&search=0xE1DD270288B4E6030699E45FA1715D88E1DF1F24" | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/git-core_ubuntu_ppa.gpg
-                for ((i=1; i <= ${NET_RETRY_COUNT:-3}; i++)); do
-                    sudo -E add-apt-repository -y ppa:git-core/ppa && break || sleep 10
-                done
+                if ! git_version=$(git --version 2>/dev/null); then
+                    git_version=0.0.0
+                fi
+                # Extract version number from e.g. "git version 2.7.4"
+                version=${git_version##* }
+                echo "Git version: $version"
+                required_git_version="2.9"
+                if [[ ${GIT_FETCH_JOBS:-1} != "1" ]] && [[ "$(printf '%s\n' "$required" "$version" | sort -V | head -n1)" != "$required" ]]; then
+                    # Need (newer) git, and the older Ubuntu container may require requesting the key manually using port 80
+                    key_server="keyserver.boost.org"
+                    echo "Downloading key from $key_server"
+                    curl -sSL --retry ${NET_RETRY_COUNT:-5} "https://$key_server/pks/lookup?op=get&search=0xE1DD270288B4E6030699E45FA1715D88E1DF1F24" | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/git-core_ubuntu_ppa.gpg
+                    for ((i=1; i <= ${NET_RETRY_COUNT:-3}; i++)); do
+                        sudo -E add-apt-repository -y ppa:git-core/ppa && break || sleep 10
+                    done
+                fi
                 apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
                 osver=$(lsb_release -sr | cut -f1 -d.)
                 pkgs="g++ git xz-utils"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Copyright 2018-2021 Peter Dimov
-# Copyright 2021-2025 Alexander Grund
+# Copyright 2021-2026 Alexander Grund
 # Distributed under the Boost Software License, Version 1.0.
 # See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
 
-cmake_minimum_required(VERSION 3.5...3.16)
+cmake_minimum_required(VERSION 3.5...3.31)
 
 project(boost_ci VERSION "${BOOST_SUPERPROJECT_VERSION}" LANGUAGES CXX)
 

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 Alexander Grund
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE or www.boost.org/LICENSE_1_0.txt)
+
+require-b2 5.2 ;
+
+constant boost_dependencies :
+    /boost/atomic//boost_atomic ;
+
+project /boost/boost_ci
+    : common-requirements
+        <include>include
+    ;
+
+explicit
+    [ alias boost_boost_ci : build//boost_boost_ci ]
+    [ alias all : boost_boost_ci test ]
+    ;
+
+call-if : boost-library boost_ci
+    : install boost_boost_ci
+    ;

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -5,11 +5,9 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE or www.boost.org/LICENSE_1_0.txt)
 
-import configure ;
-
 project
   : source-location ../src
-  : common-requirements <library>$(boost_dependencies)
+  : common-requirements <library>$(boost_dependencies)/<warnings-as-errors>off
  ;
 
 lib boost_boost_ci

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -1,25 +1,18 @@
 # Boost CI Test Build Jamfile
 
-# Copyright (c) 2022 Alexander Grund
+# Copyright (c) 2022 - 2026 Alexander Grund
 # 
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE or www.boost.org/LICENSE_1_0.txt)
 
 import configure ;
 
-local requirements =
-  <link>shared:<define>BOOST_BOOST_CI_DYN_LINK=1
-  <library>/boost/atomic//boost_atomic
-  ;
-
-project boost/ci
+project
   : source-location ../src
-  : requirements $(requirements)
-  : usage-requirements $(requirements)
-  ;
+  : common-requirements <library>$(boost_dependencies)
+ ;
 
-lib boost_ci
+lib boost_boost_ci
   : boost_ci.cpp
+  : requirements  <link>shared:<define>BOOST_BOOST_CI_DYN_LINK=1
   ;
-
-boost-install boost_ci ;

--- a/ci/common_install.sh
+++ b/ci/common_install.sh
@@ -118,9 +118,21 @@ esac
 export BOOST_ROOT="$(pwd)"
 export PATH="$(pwd):$PATH"
 
-git --version
+if ! git_version=$(git --version 2>/dev/null); then
+    unset GIT_FETCH_JOBS
+else
+    # Extract version number from e.g. "git version 2.7.4"
+    version=${git_version##* }
+    echo "Git version: $version"
+    required_git_version="2.9"
+    if [[ ${GIT_FETCH_JOBS:-1} != "1" ]] && [[ "$(printf '%s\n' "$required_git_version" "$version" | sort -V | head -n1)" != "$required_git_version" ]]; then
+        echo "Parallel git fetch requires version $required_git_version, falling back to serial fetch"
+        unset GIT_FETCH_JOBS
+    fi
+fi
+
 DEPINST_ARGS=()
-if [[ -n "$GIT_FETCH_JOBS" ]]; then
+if [[ -n $GIT_FETCH_JOBS ]]; then
     DEPINST_ARGS+=("--git_args" "--jobs $GIT_FETCH_JOBS")
 fi
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -9,7 +9,7 @@ import os ;
 import testing ;
 
 project : requirements
-      <library>/boost/ci//boost_ci
+      <library>/boost/boost_ci//boost_boost_ci
     ;
 
 local B2_ADDRESS_MODEL = [ os.environ B2_ADDRESS_MODEL ] ;

--- a/test/cmake_test/CMakeLists.txt
+++ b/test/cmake_test/CMakeLists.txt
@@ -1,8 +1,8 @@
-# Copyright 2021 Alexander Grund
+# Copyright 2021-2026 Alexander Grund
 # Distributed under the Boost Software License, Version 1.0.
 # See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
 
-cmake_minimum_required(VERSION 3.5...3.16)
+cmake_minimum_required(VERSION 3.5...3.31)
 
 project(cmake_subdir_test LANGUAGES CXX)
 


### PR DESCRIPTION
I had to adjust a few things in the Jamfiles so they match the expected naming convention (`boost_<name>` where `<name>` is `boost_ci` here) and the "modularised layout".

@grafikrobot @grisumbras Could you take a look please? 

It might also benefit those using these files as templates, e.g. for new/proposed libraries. So they should be good examples.

Note that I want to keep "boost_ci" as the name to match the repo name. Also just "ci" might be used by an actual library in the future so I guess boost-ci made sense