### PR TITLE
Remove test repo from "reusable" workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ on:
 jobs:
   call-boost-ci:
     name: Run Boost.CI
-    uses: boostorg/boost-ci/.github/workflows/reusable.yml@remove_test-repo-from-reusable
+    uses: boostorg/boost-ci/.github/workflows/reusable.yml@master
     # Customization:
     with:
       enable_reflection: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ on:
 jobs:
   call-boost-ci:
     name: Run Boost.CI
-    uses: boostorg/boost-ci/.github/workflows/reusable.yml@master
+    uses: boostorg/boost-ci/.github/workflows/reusable.yml@remove_test-repo-from-reusable
     # Customization:
     with:
       enable_reflection: true

--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -372,9 +372,6 @@ jobs:
         run: |
             SOURCE_KEYS=("${{join(matrix.source_keys, '" "')}}")
             SOURCES=("${{join(matrix.sources, '" "')}}")
-            # Add this by default
-            SOURCE_KEYS+=('0x1E9377A2BA9EF27F')
-            SOURCES+=(ppa:ubuntu-toolchain-r/test)
 
             ci/add-apt-keys.sh "${SOURCE_KEYS[@]}"
             # Initial update before adding sources required to get e.g. keys

--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -132,8 +132,8 @@ jobs:
           all_jobs = [
             # libstdc++ (by default: disabled (see exclude_cxxstd, exclude_compiler),
             #            tests are pre-C++11 standard; gcc-4.7 is not fully compliant)
-              {"compiler": "gcc-4.4",   "cxxstd": "98",                "os": "ubuntu-latest", "container": "ubuntu:16.04"},
-              {"compiler": "gcc-4.6",   "cxxstd": "03,0x",             "os": "ubuntu-latest", "container": "ubuntu:16.04"},
+              {"compiler": "gcc-4.4",   "cxxstd": "98",                "os": "ubuntu-latest", "container": "ubuntu:16.04", "source_keys": "0x1E9377A2BA9EF27F", "sources": "ppa:ubuntu-toolchain-r/test"},
+              {"compiler": "gcc-4.6",   "cxxstd": "03,0x",             "os": "ubuntu-latest", "container": "ubuntu:16.04", "source_keys": "0x1E9377A2BA9EF27F", "sources": "ppa:ubuntu-toolchain-r/test"},
               {"compiler": "gcc-4.7",   "cxxstd": "03,11",             "os": "ubuntu-latest", "container": "ubuntu:16.04"},
             # libstdc++
               {"compiler": "gcc-4.7",   "cxxstd": "11",                "os": "ubuntu-latest", "container": "ubuntu:16.04"},


### PR DESCRIPTION
Causes flaky CI when Launchpad connection is unstable and isn't required for most jobs

Part of #252 which shouldn't cause any issues.