### PR TITLE
Update key hashes used by ubuntu-toolchain-r/test

### DIFF
--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -132,8 +132,8 @@ jobs:
           all_jobs = [
             # libstdc++ (by default: disabled (see exclude_cxxstd, exclude_compiler),
             #            tests are pre-C++11 standard; gcc-4.7 is not fully compliant)
-              {"compiler": "gcc-4.4",   "cxxstd": "98",                "os": "ubuntu-latest", "container": "ubuntu:16.04", "source_keys": "0x1E9377A2BA9EF27F", "sources": "ppa:ubuntu-toolchain-r/test"},
-              {"compiler": "gcc-4.6",   "cxxstd": "03,0x",             "os": "ubuntu-latest", "container": "ubuntu:16.04", "source_keys": "0x1E9377A2BA9EF27F", "sources": "ppa:ubuntu-toolchain-r/test"},
+              {"compiler": "gcc-4.4",   "cxxstd": "98",                "os": "ubuntu-latest", "container": "ubuntu:16.04", "source_keys": "0x2C277A0A352154E5", "sources": "ppa:ubuntu-toolchain-r/test"},
+              {"compiler": "gcc-4.6",   "cxxstd": "03,0x",             "os": "ubuntu-latest", "container": "ubuntu:16.04", "source_keys": "0x2C277A0A352154E5", "sources": "ppa:ubuntu-toolchain-r/test"},
               {"compiler": "gcc-4.7",   "cxxstd": "03,11",             "os": "ubuntu-latest", "container": "ubuntu:16.04"},
             # libstdc++
               {"compiler": "gcc-4.7",   "cxxstd": "11",                "os": "ubuntu-latest", "container": "ubuntu:16.04"},

--- a/ci/add-apt-keys.sh
+++ b/ci/add-apt-keys.sh
@@ -21,9 +21,9 @@ fi
 function do_add_key
 {
     key_url=$1
-    # If a keyserver URL (e.g. http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F)
+    # If a keyserver URL (e.g. http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2C277A0A352154E5)
     # use the hash as the filename,
-    # if it is an ID, e.g. 0x1E9377A2BA9EF27F, use it as the filename, and http://keyserver.ubuntu.com/pks/lookup as the URL
+    # if it is an ID, e.g. 0x2C277A0A352154E5, use it as the filename, and http://keyserver.ubuntu.com/pks/lookup as the URL
     # else assume the URL contains a filename, e.g. https://apt.llvm.org/llvm-snapshot.gpg.key
     if [[ "$key_url" =~ .*keyserver.*search=0x([A-F0-9]+) ]]; then
         keyfilename="${BASH_REMATCH[1]}.key"

--- a/ci/drone/linux-cxx-install.sh
+++ b/ci/drone/linux-cxx-install.sh
@@ -46,7 +46,7 @@ function add_repository_toolchain {
     } > "/etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-${VERSION_CODENAME}.list"
     key_server="keyserver.boost.org"
     echo "Downloading toolchain gpg key via ${key_server}"
-    curl ${curl_extra_options} --connect-timeout 15 -sSL --retry "${NET_RETRY_COUNT:-5}" "https://${key_server}/pks/lookup?op=get&search=0x1E9377A2BA9EF27F" | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/toolchain-r.gpg
+    curl ${curl_extra_options} --connect-timeout 15 -sSL --retry "${NET_RETRY_COUNT:-5}" "https://${key_server}/pks/lookup?op=get&search=0x2C277A0A352154E5" | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/toolchain-r.gpg
 }
 
 echo ">>>>> APT: REPOSITORIES..."


### PR DESCRIPTION
The old one a weak key algorithm that is no longer accepted by some systems.