### PR TITLE
Allow filtering of CMake jobs based on compiler

### DIFF
--- a/.github/workflows/ci_test_opposite.yml
+++ b/.github/workflows/ci_test_opposite.yml
@@ -45,7 +45,7 @@ jobs:
       enable_multiarch: false
       enable_reflection: true
       enable_sanitizers: false
-      exclude_compiler: 'gcc-10,clang-10,msvc-14.2'
+      exclude_compiler: 'gcc-10,clang-10,msvc-14.5'
       exclude_cxxstd: '98,03,0x,0y,14,2a,20,2b,23,2c,26'  # only do C++11 and C++17 jobs
       exclude_os: 'ubuntu:16.04,macos,windows-2022'
     # no secrets defined which disables coverage and coverity scan

--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -180,7 +180,7 @@ jobs:
           def filter_multi_valued(in_list, key_name, excluded):
               """Remove all entries from the value identified by key_name that are contained in excluded (comma-separated).
                  Omit the entry when the attribute is empty, keep it if the attribute is not present."""
-              excluded_values = {x.strip() for x in excluded.split(',')}
+              excluded_values = {x.strip() for x in excluded.split(',')} if isinstance(excluded, str) else excluded
               for entry in in_list:
                   try:
                       values = [x.strip() for x in entry[key_name].split(',')]
@@ -232,9 +232,9 @@ jobs:
                   {"compiler": "gcc-11",    "cxxstd": "11,14,17,20",       "os": "ubuntu-22.04"},
                   {"compiler": "gcc-12",    "cxxstd": "11,14,17,20",       "os": "ubuntu-22.04"},
                   {"compiler": "gcc-13",    "cxxstd": "11,14,17,20,2b",    "os": "ubuntu-24.04"},
-                  {"name": "coverage-gcc-linux", "coverage": "yes",
+                  {"name": "Coverage w/ GCC on Linux", "coverage": "yes",
                    "compiler": "gcc-13",    "cxxstd": "2b",                "os": "ubuntu-24.04", "install": "g++-13-multilib gcc-multilib", "address-model": "32,64" },
-                  {"name": "sanitize-gcc-linux", "sanitize": "yes",
+                  {"name": "GCC w/ sanitizers", "sanitize": "yes",
                    "compiler": "gcc-13",    "cxxstd": "11,14,17,20",       "os": "ubuntu-24.04"},
                   {"compiler": "gcc-14",    "cxxstd": "11,14,17,20,23",    "os": "ubuntu-24.04"},
                   {"compiler": "gcc-15",    "cxxstd": "11,14,17,20,23,2c", "os": "ubuntu-latest", "container": "ubuntu:26.04"},
@@ -366,8 +366,14 @@ jobs:
                 { "name": "Min. CMake", "cmake_version": os.environ["MIN_CMAKE_VERSION"],
                   "os": "ubuntu-latest",            "build_shared": "ON",  "build_type": "Debug", "generator": "Unix Makefiles" },
               ]
+              filtered = all_jobs
+              compiler_map = {
+                "msvc-14.3": "Visual Studio 17 2022",
+                "msvc-14.5": "Visual Studio 18 2026",
+              }
+              filtered = filter_multi_valued(filtered, 'generator', [compiler_map.get(x.strip(), x.strip()) for x in os.environ['EXCLUDE_COMPILER'].split(',')])
 
-              write_matrix('cmake-matrix', all_jobs)
+              write_matrix('cmake-matrix', filtered)
         shell: python
         env:
           ENABLE_POSIX: ${{ inputs.enable_posix }}

--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -332,6 +332,8 @@ jobs:
               filtered = filter_multi_valued(filtered, 'cxxstd', os.environ['EXCLUDE_CXXSTD'])
               filtered = filter_multi_valued(filtered, 'toolset', os.environ['EXCLUDE_COMPILER'])
               filtered = filter_os(filtered, os.environ['EXCLUDE_OS'])
+              if not os.environ.get('CODECOV_TOKEN') and not is_true('ENABLE_PR_COVERAGE'):
+                  filtered = filter_yes_values(filtered, 'coverage')
               if not is_true('ENABLE_32BIT'):
                   filtered = filter_multi_valued(filtered, 'address-model', '32')
               if not is_true('ENABLE_CYGWIN'):

--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -161,98 +161,21 @@ jobs:
   generate-job-matrix:
     runs-on: ubuntu-latest
     outputs:
-      posix-matrix: ${{ steps.posix-matrix.outputs.matrix }}
-      windows-matrix: ${{ steps.windows-matrix.outputs.matrix }}
-      mingw-matrix: ${{ steps.mingw-matrix.outputs.matrix }}
-      cmake-matrix: ${{ steps.cmake-matrix.outputs.matrix }}
+      posix-matrix: ${{ steps.generate-matrix.outputs.posix-matrix }}
+      windows-matrix: ${{ steps.generate-matrix.outputs.windows-matrix }}
+      mingw-matrix: ${{ steps.generate-matrix.outputs.mingw-matrix }}
+      cmake-matrix: ${{ steps.generate-matrix.outputs.cmake-matrix }}
     steps:
-      - id: posix-matrix
-        name: Posix
-        if: ${{ inputs.enable_posix }}
+      - id: generate-matrix
+        name: Generate job matrices
         run: |
           import json, os
 
-          # All jobs
-          all_jobs = [
-            # libstdc++ (by default: disabled (see exclude_cxxstd, exclude_compiler),
-            #            tests are pre-C++11 standard; gcc-4.7 is not fully compliant)
-              {"compiler": "gcc-4.4",   "cxxstd": "98",                "os": "ubuntu-latest", "container": "ubuntu:16.04", "source_keys": "0x2C277A0A352154E5", "sources": "ppa:ubuntu-toolchain-r/test"},
-              {"compiler": "gcc-4.6",   "cxxstd": "03,0x",             "os": "ubuntu-latest", "container": "ubuntu:16.04", "source_keys": "0x2C277A0A352154E5", "sources": "ppa:ubuntu-toolchain-r/test"},
-              {"compiler": "gcc-4.7",   "cxxstd": "03,11",             "os": "ubuntu-latest", "container": "ubuntu:16.04"},
-            # libstdc++
-              {"compiler": "gcc-4.7",   "cxxstd": "11",                "os": "ubuntu-latest", "container": "ubuntu:16.04"},
-              {"compiler": "gcc-4.8",   "cxxstd": "11",                "os": "ubuntu-latest", "container": "ubuntu:16.04"},
-              {"compiler": "gcc-4.9",   "cxxstd": "11",                "os": "ubuntu-latest", "container": "ubuntu:16.04"},
-              {"compiler": "gcc-5",     "cxxstd": "11,14,1z",          "os": "ubuntu-latest", "container": "ubuntu:18.04"},
-              {"compiler": "gcc-6",     "cxxstd": "11,14,17",          "os": "ubuntu-latest", "container": "ubuntu:18.04"},
-              {"compiler": "gcc-7",     "cxxstd": "11,14,17",          "os": "ubuntu-latest", "container": "ubuntu:20.04"},
-              {"compiler": "gcc-8",     "cxxstd": "11,14,17,2a",       "os": "ubuntu-latest", "container": "ubuntu:20.04"},
-              {"compiler": "gcc-9",     "cxxstd": "11,14,17,2a",       "os": "ubuntu-22.04"},
-              {"compiler": "gcc-10",    "cxxstd": "11,14,17,20",       "os": "ubuntu-22.04"},
-              {"compiler": "gcc-11",    "cxxstd": "11,14,17,20",       "os": "ubuntu-22.04"},
-              {"compiler": "gcc-12",    "cxxstd": "11,14,17,20",       "os": "ubuntu-22.04"},
-              {"compiler": "gcc-13",    "cxxstd": "11,14,17,20,2b",    "os": "ubuntu-24.04"},
-              {"name": "coverage-gcc-linux", "coverage": "yes",
-               "compiler": "gcc-13",    "cxxstd": "2b",                "os": "ubuntu-24.04", "install": "g++-13-multilib gcc-multilib", "address-model": "32,64" },
-              {"name": "sanitize-gcc-linux", "sanitize": "yes",
-               "compiler": "gcc-13",    "cxxstd": "11,14,17,20",       "os": "ubuntu-24.04"},
-              {"compiler": "gcc-14",    "cxxstd": "11,14,17,20,23",    "os": "ubuntu-24.04"},
-              {"compiler": "gcc-15",    "cxxstd": "11,14,17,20,23,2c", "os": "ubuntu-latest", "container": "ubuntu:26.04"},
-              {"compiler": "gcc-16",    "cxxstd": "11,14,17,20,23,26", "os": "ubuntu-latest", "container": "ubuntu:26.04"},
-              {"compiler": "clang-3.5", "cxxstd": "11",                "os": "ubuntu-latest", "container": "ubuntu:16.04"},
-              {"compiler": "clang-3.6", "cxxstd": "11,14",             "os": "ubuntu-latest", "container": "ubuntu:16.04"},
-              {"compiler": "clang-3.7", "cxxstd": "11,14",             "os": "ubuntu-latest", "container": "ubuntu:16.04"},
-              {"compiler": "clang-3.8", "cxxstd": "11,14",             "os": "ubuntu-latest", "container": "ubuntu:16.04"},
-              {"compiler": "clang-3.9", "cxxstd": "11,14",             "os": "ubuntu-latest", "container": "ubuntu:18.04"},
-              {"compiler": "clang-4.0", "cxxstd": "11,14",             "os": "ubuntu-latest", "container": "ubuntu:18.04"},
-              {"compiler": "clang-5.0", "cxxstd": "11,14,1z",          "os": "ubuntu-latest", "container": "ubuntu:18.04"},
-              {"compiler": "clang-6.0", "cxxstd": "11,14,17",          "os": "ubuntu-latest", "container": "ubuntu:20.04"},
-              {"compiler": "clang-7",   "cxxstd": "11,14,17",          "os": "ubuntu-latest", "container": "ubuntu:20.04"},
-              {"compiler": "clang-8",   "cxxstd": "11,14,17",          "os": "ubuntu-latest", "container": "ubuntu:20.04"},
-              {"compiler": "clang-9",   "cxxstd": "11,14,17,2a",       "os": "ubuntu-latest", "container": "ubuntu:20.04"},
-              {"compiler": "clang-10",  "cxxstd": "11,14,17,20",       "os": "ubuntu-latest", "container": "ubuntu:20.04"},
-              {"compiler": "clang-11",  "cxxstd": "11,14,17,20",       "os": "ubuntu-latest", "container": "ubuntu:20.04"},
-              {"compiler": "clang-12",  "cxxstd": "11,14,17,20",       "os": "ubuntu-latest", "container": "ubuntu:20.04"},
-              {"compiler": "clang-13",  "cxxstd": "11,14,17,20",       "os": "ubuntu-latest", "container": "ubuntu:22.04"},
-              {"compiler": "clang-14",  "cxxstd": "11,14,17,20",       "os": "ubuntu-latest", "container": "ubuntu:22.04"},
-              {"compiler": "clang-15",  "cxxstd": "11,14,17,20",       "os": "ubuntu-latest", "container": "ubuntu:22.04"},
-              {"compiler": "clang-16",  "cxxstd": "11,14,17,20,2b",    "os": "ubuntu-24.04"},
-              {"compiler": "clang-17",  "cxxstd": "11,14,17,20,23",    "os": "ubuntu-latest", "container": "ubuntu:24.04"},
-              {"compiler": "clang-18",  "cxxstd": "11,14,17,20,23,2c", "os": "ubuntu-24.04"},
-              {"compiler": "clang-19",  "cxxstd": "11,14,17,20,23,2c", "os": "ubuntu-24.04"},
-              {"compiler": "clang-20",  "cxxstd": "11,14,17,20,23,2c", "os": "ubuntu-latest", "container": "ubuntu:25.04"},
-              {"compiler": "clang-21",  "cxxstd": "11,14,17,20,23,2c", "os": "ubuntu-latest", "container": "ubuntu:26.04"},
-              {"compiler": "clang-22",  "cxxstd": "11,14,17,20,23,2c", "os": "ubuntu-latest", "container": "ubuntu:26.04"},
-              {"compiler": "icpx-2025", "cxxstd": "11,14,17,20,23,2c", "os": "ubuntu-latest", "container": "intel/oneapi-hpckit:2025.2.2-0-devel-ubuntu24.04"},
-            # libc++
-              {"stdlib": "libc++",
-               "compiler": "clang-6.0", "cxxstd": "11,14",             "os": "ubuntu-latest", "container": "ubuntu:18.04", "install": "clang-6.0 libc++-dev libc++abi-dev"},
-              {"stdlib": "libc++",
-               "compiler": "clang-7",   "cxxstd": "11,14,17",          "os": "ubuntu-latest", "container": "ubuntu:20.04"},
-              {"name": "Clang w/ sanitizers", "sanitize": "yes", "stdlib": "libc++",
-               "compiler": "clang-12",  "cxxstd": "11,14,17,20",       "os": "ubuntu-latest", "container": "ubuntu:20.04"}, 
-            # MacOS
-              {"name": "MacOS sanitize w/ clang",
-               "os": "macos-14", "compiler": "clang",     "cxxstd": "11,14,17,20,2b",    "sanitize": "yes"},
-              {"os": "macos-15", "compiler": "clang-16",  "cxxstd": "11,14,17,20,2b",    "xcode_app": "Xcode_16.2"},
-              {"os": "macos-15", "compiler": "clang-18",  "cxxstd": "11,14,17,20,2b"},
-              {"os": "macos-26", "compiler": "clang-20",  "cxxstd": "11,14,17,20,23,2c"},
-            # Coverity
-              {"name": "Coverity Scan w/ Clang on Linux", "coverity": "yes",
-               "compiler": "clang-12",  "cxxstd": "20",                "os": "ubuntu-22.04", "ccache": "no"},
-            # Arm64
-              {"name": "ARM64 w/ GCC",
-               "compiler": "gcc-13",   "cxxstd": "11,14,17,20,2b",     "os": "ubuntu-24.04-arm"},
-            # Big-Endian
-              {"name": "bigendian-s390x", "multiarch": "yes",
-               "compiler": "clang",     "cxxstd": "17",                "os": "ubuntu-22.04", "ccache": "no", "distro": "fedora", "edition": "34", "arch": "s390x"},
-            # Reflection
-              {"name": "GCC 16 w/ reflection",
-               "compiler": "gcc-16", "cxxstd": "26",                   "os": "ubuntu-latest", "container": "ubuntu:26.04", "reflection": "yes", "cxxflags": "-freflection"},
-          ]
-
+          # ═══════════════════════════════════════════════════════════════
+          # Helper functions
+          # ═══════════════════════════════════════════════════════════════
           def is_true(env_var):
-              return os.environ.get(env_var).lower() == 'true'
+              return os.environ.get(env_var).lower() in ('true', '1')
 
           def filter_multi_valued(in_list, key_name, excluded):
               """Remove all entries from the value identified by key_name that are contained in excluded (comma-separated).
@@ -269,182 +192,199 @@ jobs:
                           entry[key_name] = ",".join(remaining_values)
                           yield entry
 
+          def get_os(job):
+              """Extract OS from job"""
+              # "sys": MinGW; "os" doesn't matter if "container" is set; unify "ubuntu-22.04|ubuntu:22.04"
+              return job.get('sys', job.get('container', job.get('os', ''))).replace('-', ':')
           def filter_os(in_list, excluded):
               """Remove all jobs that match any of the excluded OS (comma-separated, supports partial matches)"""
               excluded_values = [v for v in (x.strip().replace('-', ':') for x in excluded.split(',')) if v]
-              return (job for job in in_list if not any(ev in job.get('container', job['os']).replace('-', ':') for ev in excluded_values))
+              return (job for job in in_list if not any(ev in get_os(job) for ev in excluded_values))
 
           def filter_yes_values(in_list, key_name):
               """Remove all entries with value 'yes' for the key"""
-              return (e for e in in_list if not e.get(key_name) == "yes")
+              return (job for job in in_list if not job.get(key_name) == "yes")
 
-          filtered = all_jobs
-          filtered = filter_multi_valued(filtered, 'cxxstd', os.environ['EXCLUDE_CXXSTD'])
-          filtered = filter_multi_valued(filtered, 'compiler', os.environ['EXCLUDE_COMPILER'])
-          filtered = filter_os(filtered, os.environ['EXCLUDE_OS'])
-          if not is_true('ENABLE_32BIT'):
-              filtered = filter_multi_valued(filtered, 'address-model', '32')
-          if not is_true('ENABLE_MULTIARCH'):
-              filtered = filter_yes_values(filtered, 'multiarch')
-          if not is_true('ENABLE_SANITIZERS'):
-              filtered = filter_yes_values(filtered, 'sanitize')
-          if not os.environ.get('CODECOV_TOKEN') and os.environ.get('$ENABLE_PR_COVERAGE') != 'true':
-              filtered = filter_yes_values(filtered, 'coverage')
-          if not os.environ.get('COVERITY_SCAN_TOKEN'):
-              filtered = filter_yes_values(filtered, 'coverity')
-          if not is_true('ENABLE_REFLECTION'):
-              filtered = filter_yes_values(filtered, 'reflection')
+          def write_matrix(name, jobs):
+              with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+                  print(f"{name}={json.dumps({'include': list(jobs)})}", file=fh)
 
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-              print(f"matrix={json.dumps({'include': list(filtered)})}", file=fh)
+          # ═══════════════════════════════════════════════════════════════
+          # Posix matrix
+          # ═══════════════════════════════════════════════════════════════
+          if is_true('ENABLE_POSIX'):
+              all_jobs = [
+                # libstdc++ (by default: disabled (see exclude_cxxstd, exclude_compiler),
+                #            tests are pre-C++11 standard; gcc-4.7 is not fully compliant)
+                  {"compiler": "gcc-4.4",   "cxxstd": "98",                "os": "ubuntu-latest", "container": "ubuntu:16.04", "source_keys": "0x2C277A0A352154E5", "sources": "ppa:ubuntu-toolchain-r/test"},
+                  {"compiler": "gcc-4.6",   "cxxstd": "03,0x",             "os": "ubuntu-latest", "container": "ubuntu:16.04", "source_keys": "0x2C277A0A352154E5", "sources": "ppa:ubuntu-toolchain-r/test"},
+                  {"compiler": "gcc-4.7",   "cxxstd": "03,11",             "os": "ubuntu-latest", "container": "ubuntu:16.04"},
+                # libstdc++
+                  {"compiler": "gcc-4.7",   "cxxstd": "11",                "os": "ubuntu-latest", "container": "ubuntu:16.04"},
+                  {"compiler": "gcc-4.8",   "cxxstd": "11",                "os": "ubuntu-latest", "container": "ubuntu:16.04"},
+                  {"compiler": "gcc-4.9",   "cxxstd": "11",                "os": "ubuntu-latest", "container": "ubuntu:16.04"},
+                  {"compiler": "gcc-5",     "cxxstd": "11,14,1z",          "os": "ubuntu-latest", "container": "ubuntu:18.04"},
+                  {"compiler": "gcc-6",     "cxxstd": "11,14,17",          "os": "ubuntu-latest", "container": "ubuntu:18.04"},
+                  {"compiler": "gcc-7",     "cxxstd": "11,14,17",          "os": "ubuntu-latest", "container": "ubuntu:20.04"},
+                  {"compiler": "gcc-8",     "cxxstd": "11,14,17,2a",       "os": "ubuntu-latest", "container": "ubuntu:20.04"},
+                  {"compiler": "gcc-9",     "cxxstd": "11,14,17,2a",       "os": "ubuntu-22.04"},
+                  {"compiler": "gcc-10",    "cxxstd": "11,14,17,20",       "os": "ubuntu-22.04"},
+                  {"compiler": "gcc-11",    "cxxstd": "11,14,17,20",       "os": "ubuntu-22.04"},
+                  {"compiler": "gcc-12",    "cxxstd": "11,14,17,20",       "os": "ubuntu-22.04"},
+                  {"compiler": "gcc-13",    "cxxstd": "11,14,17,20,2b",    "os": "ubuntu-24.04"},
+                  {"name": "coverage-gcc-linux", "coverage": "yes",
+                   "compiler": "gcc-13",    "cxxstd": "2b",                "os": "ubuntu-24.04", "install": "g++-13-multilib gcc-multilib", "address-model": "32,64" },
+                  {"name": "sanitize-gcc-linux", "sanitize": "yes",
+                   "compiler": "gcc-13",    "cxxstd": "11,14,17,20",       "os": "ubuntu-24.04"},
+                  {"compiler": "gcc-14",    "cxxstd": "11,14,17,20,23",    "os": "ubuntu-24.04"},
+                  {"compiler": "gcc-15",    "cxxstd": "11,14,17,20,23,2c", "os": "ubuntu-latest", "container": "ubuntu:26.04"},
+                  {"compiler": "gcc-16",    "cxxstd": "11,14,17,20,23,26", "os": "ubuntu-latest", "container": "ubuntu:26.04"},
+                  {"compiler": "clang-3.5", "cxxstd": "11",                "os": "ubuntu-latest", "container": "ubuntu:16.04"},
+                  {"compiler": "clang-3.6", "cxxstd": "11,14",             "os": "ubuntu-latest", "container": "ubuntu:16.04"},
+                  {"compiler": "clang-3.7", "cxxstd": "11,14",             "os": "ubuntu-latest", "container": "ubuntu:16.04"},
+                  {"compiler": "clang-3.8", "cxxstd": "11,14",             "os": "ubuntu-latest", "container": "ubuntu:16.04"},
+                  {"compiler": "clang-3.9", "cxxstd": "11,14",             "os": "ubuntu-latest", "container": "ubuntu:18.04"},
+                  {"compiler": "clang-4.0", "cxxstd": "11,14",             "os": "ubuntu-latest", "container": "ubuntu:18.04"},
+                  {"compiler": "clang-5.0", "cxxstd": "11,14,1z",          "os": "ubuntu-latest", "container": "ubuntu:18.04"},
+                  {"compiler": "clang-6.0", "cxxstd": "11,14,17",          "os": "ubuntu-latest", "container": "ubuntu:20.04"},
+                  {"compiler": "clang-7",   "cxxstd": "11,14,17",          "os": "ubuntu-latest", "container": "ubuntu:20.04"},
+                  {"compiler": "clang-8",   "cxxstd": "11,14,17",          "os": "ubuntu-latest", "container": "ubuntu:20.04"},
+                  {"compiler": "clang-9",   "cxxstd": "11,14,17,2a",       "os": "ubuntu-latest", "container": "ubuntu:20.04"},
+                  {"compiler": "clang-10",  "cxxstd": "11,14,17,20",       "os": "ubuntu-latest", "container": "ubuntu:20.04"},
+                  {"compiler": "clang-11",  "cxxstd": "11,14,17,20",       "os": "ubuntu-latest", "container": "ubuntu:20.04"},
+                  {"compiler": "clang-12",  "cxxstd": "11,14,17,20",       "os": "ubuntu-latest", "container": "ubuntu:20.04"},
+                  {"compiler": "clang-13",  "cxxstd": "11,14,17,20",       "os": "ubuntu-latest", "container": "ubuntu:22.04"},
+                  {"compiler": "clang-14",  "cxxstd": "11,14,17,20",       "os": "ubuntu-latest", "container": "ubuntu:22.04"},
+                  {"compiler": "clang-15",  "cxxstd": "11,14,17,20",       "os": "ubuntu-latest", "container": "ubuntu:22.04"},
+                  {"compiler": "clang-16",  "cxxstd": "11,14,17,20,2b",    "os": "ubuntu-24.04"},
+                  {"compiler": "clang-17",  "cxxstd": "11,14,17,20,23",    "os": "ubuntu-latest", "container": "ubuntu:24.04"},
+                  {"compiler": "clang-18",  "cxxstd": "11,14,17,20,23,2c", "os": "ubuntu-24.04"},
+                  {"compiler": "clang-19",  "cxxstd": "11,14,17,20,23,2c", "os": "ubuntu-24.04"},
+                  {"compiler": "clang-20",  "cxxstd": "11,14,17,20,23,2c", "os": "ubuntu-latest", "container": "ubuntu:25.04"},
+                  {"compiler": "clang-21",  "cxxstd": "11,14,17,20,23,2c", "os": "ubuntu-latest", "container": "ubuntu:26.04"},
+                  {"compiler": "clang-22",  "cxxstd": "11,14,17,20,23,2c", "os": "ubuntu-latest", "container": "ubuntu:26.04"},
+                  {"compiler": "icpx-2025", "cxxstd": "11,14,17,20,23,2c", "os": "ubuntu-latest", "container": "intel/oneapi-hpckit:2025.2.2-0-devel-ubuntu24.04"},
+                # libc++
+                  {"stdlib": "libc++",
+                   "compiler": "clang-6.0", "cxxstd": "11,14",             "os": "ubuntu-latest", "container": "ubuntu:18.04", "install": "clang-6.0 libc++-dev libc++abi-dev"},
+                  {"stdlib": "libc++",
+                   "compiler": "clang-7",   "cxxstd": "11,14,17",          "os": "ubuntu-latest", "container": "ubuntu:20.04"},
+                  {"name": "Clang w/ sanitizers", "sanitize": "yes", "stdlib": "libc++",
+                   "compiler": "clang-12",  "cxxstd": "11,14,17,20",       "os": "ubuntu-latest", "container": "ubuntu:20.04"}, 
+                # MacOS
+                  {"name": "MacOS sanitize w/ clang",
+                   "os": "macos-14", "compiler": "clang",     "cxxstd": "11,14,17,20,2b",    "sanitize": "yes"},
+                  {"os": "macos-15", "compiler": "clang-16",  "cxxstd": "11,14,17,20,2b",    "xcode_app": "Xcode_16.2"},
+                  {"os": "macos-15", "compiler": "clang-18",  "cxxstd": "11,14,17,20,2b"},
+                  {"os": "macos-26", "compiler": "clang-20",  "cxxstd": "11,14,17,20,23,2c"},
+                # Coverity
+                  {"name": "Coverity Scan w/ Clang on Linux", "coverity": "yes",
+                   "compiler": "clang-12",  "cxxstd": "20",                "os": "ubuntu-22.04", "ccache": "no"},
+                # Arm64
+                  {"name": "ARM64 w/ GCC",
+                   "compiler": "gcc-13",   "cxxstd": "11,14,17,20,2b",     "os": "ubuntu-24.04-arm"},
+                # Big-Endian
+                  {"name": "bigendian-s390x", "multiarch": "yes",
+                   "compiler": "clang",     "cxxstd": "17",                "os": "ubuntu-22.04", "ccache": "no", "distro": "fedora", "edition": "34", "arch": "s390x"},
+                # Reflection
+                  {"name": "GCC 16 w/ reflection",
+                   "compiler": "gcc-16", "cxxstd": "26",                   "os": "ubuntu-latest", "container": "ubuntu:26.04", "reflection": "yes", "cxxflags": "-freflection"},
+              ]
+
+              filtered = all_jobs
+              filtered = filter_multi_valued(filtered, 'cxxstd', os.environ['EXCLUDE_CXXSTD'])
+              filtered = filter_multi_valued(filtered, 'compiler', os.environ['EXCLUDE_COMPILER'])
+              filtered = filter_os(filtered, os.environ['EXCLUDE_OS'])
+              if not is_true('ENABLE_32BIT'):
+                  filtered = filter_multi_valued(filtered, 'address-model', '32')
+              if not is_true('ENABLE_MULTIARCH'):
+                  filtered = filter_yes_values(filtered, 'multiarch')
+              if not is_true('ENABLE_SANITIZERS'):
+                  filtered = filter_yes_values(filtered, 'sanitize')
+              if not os.environ.get('CODECOV_TOKEN') and not is_true('ENABLE_PR_COVERAGE'):
+                  filtered = filter_yes_values(filtered, 'coverage')
+              if not os.environ.get('COVERITY_SCAN_TOKEN'):
+                  filtered = filter_yes_values(filtered, 'coverity')
+              if not is_true('ENABLE_REFLECTION'):
+                  filtered = filter_yes_values(filtered, 'reflection')
+
+              write_matrix('posix-matrix', filtered)
+
+          # ═══════════════════════════════════════════════════════════════
+          # Windows matrix
+          # ═══════════════════════════════════════════════════════════════
+          if is_true('ENABLE_WINDOWS'):
+              all_jobs = [
+                {"toolset": "msvc-14.3", "cxxstd": "14,17,20,latest", "address-model": "32,64", "os": "windows-2022"},
+                {"toolset": "msvc-14.5", "cxxstd": "14,17,20,latest", "address-model": "32,64", "os": "windows-2025-vs2026"},
+                {"toolset": "msvc-14.3", "cxxstd": "14,17,20,latest", "address-model": "64", "os": "windows-11-arm"},
+                {"name": "Collect coverage w/ VS 2026", "coverage": "yes",
+                 "toolset": "msvc-14.5", "cxxstd": "latest",          "address-model": "64",    "os": "windows-2025-vs2026"},
+                {"toolset": "clang-win", "cxxstd": "14,17,latest",    "address-model": "32,64", "os": "windows-2025"},
+                {"toolset": "gcc",       "cxxstd": "11,14,17,2a",     "address-model": "64",    "os": "windows-2022"},
+                {"toolset": "gcc",       "cxxstd": "11,14,17,2a",     "address-model": "32",    "os": "windows-2025", "target-os": "cygwin"},
+                {"toolset": "gcc",       "cxxstd": "11,14,17,2a",     "address-model": "64",    "os": "windows-2025", "target-os": "cygwin"},
+              ]
+
+              filtered = all_jobs
+              filtered = filter_multi_valued(filtered, 'cxxstd', os.environ['EXCLUDE_CXXSTD'])
+              filtered = filter_multi_valued(filtered, 'toolset', os.environ['EXCLUDE_COMPILER'])
+              filtered = filter_os(filtered, os.environ['EXCLUDE_OS'])
+              if not is_true('ENABLE_32BIT'):
+                  filtered = filter_multi_valued(filtered, 'address-model', '32')
+              if not is_true('ENABLE_CYGWIN'):
+                  filtered = filter_multi_valued(filtered, 'target-os', 'cygwin')
+
+              write_matrix('windows-matrix', filtered)
+
+          # ═══════════════════════════════════════════════════════════════
+          # MinGW matrix
+          # ═══════════════════════════════════════════════════════════════
+          if is_true('ENABLE_MINGW'):
+              all_jobs = [
+                  {"sys": "MINGW32", "compiler": "gcc", "cxxstd": "11,17,20"},
+                  {"sys": "MINGW64", "compiler": "gcc", "cxxstd": "11,17,20"},
+              ]
+
+              filtered = all_jobs
+              filtered = filter_multi_valued(filtered, 'cxxstd', os.environ['EXCLUDE_CXXSTD'])
+              if not is_true('ENABLE_32BIT'):
+                  filtered = filter_multi_valued(filtered, 'sys', 'MINGW32')
+
+              write_matrix('mingw-matrix', filtered)
+
+          # ═══════════════════════════════════════════════════════════════
+          # CMake matrix
+          # ═══════════════════════════════════════════════════════════════
+          if is_true('ENABLE_CMAKE'):
+              all_jobs = [
+                { "os": "ubuntu-latest",        "build_shared": "ON",  "build_type": "Debug", "generator": "Unix Makefiles" },
+                { "os": "ubuntu-latest",        "build_shared": "OFF", "build_type": "Debug", "generator": "Unix Makefiles" },
+                { "os": "windows-2022",         "build_shared": "ON",  "build_type": "Debug", "generator": "Visual Studio 17 2022" },
+                { "os": "windows-2022",         "build_shared": "OFF", "build_type": "Debug", "generator": "Visual Studio 17 2022" },
+                { "os": "windows-2025-vs2026",  "build_shared": "OFF", "build_type": "Debug", "generator": "Visual Studio 18 2026" },
+                { "name": "Min. CMake", "cmake_version": os.environ["MIN_CMAKE_VERSION"],
+                  "os": "ubuntu-latest",            "build_shared": "ON",  "build_type": "Debug", "generator": "Unix Makefiles" },
+              ]
+
+              write_matrix('cmake-matrix', all_jobs)
         shell: python
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-          COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+          ENABLE_POSIX: ${{ inputs.enable_posix }}
+          ENABLE_WINDOWS: ${{ inputs.enable_windows }}
+          ENABLE_MINGW: ${{ inputs.enable_mingw }}
+          ENABLE_CMAKE: ${{ inputs.enable_cmake }}
           ENABLE_32BIT: ${{ inputs.enable_32bit }}
           ENABLE_MULTIARCH: ${{ inputs.enable_multiarch }}
           ENABLE_SANITIZERS: ${{ inputs.enable_sanitizers }}
           ENABLE_REFLECTION: ${{ inputs.enable_reflection }}
-          ENABLE_PR_COVERAGE: ${{inputs.enable_pr_coverage}}
-          EXCLUDE_COMPILER: ${{ inputs.exclude_compiler }}
-          EXCLUDE_CXXSTD: ${{ inputs.exclude_cxxstd }}
-          EXCLUDE_OS: ${{ inputs.exclude_os }}
-
-      - id: windows-matrix
-        name: Windows
-        if: ${{ inputs.enable_windows }}
-        run: |
-          import json, os
-
-          all_jobs = [
-            {"toolset": "msvc-14.3", "cxxstd": "14,17,20,latest", "address-model": "32,64", "os": "windows-2022"},
-            {"toolset": "msvc-14.5", "cxxstd": "14,17,20,latest", "address-model": "32,64", "os": "windows-2025-vs2026"},
-            {"toolset": "msvc-14.3", "cxxstd": "14,17,20,latest", "address-model": "64", "os": "windows-11-arm"},
-            {"name": "Collect coverage", "coverage": "yes",
-             "toolset": "msvc-14.5", "cxxstd": "latest",          "address-model": "64",    "os": "windows-2025-vs2026"},
-            {"toolset": "clang-win", "cxxstd": "14,17,latest",    "address-model": "32,64", "os": "windows-2025"},
-            {"toolset": "gcc",       "cxxstd": "11,14,17,2a",     "address-model": "64",    "os": "windows-2022"},
-            {"toolset": "gcc",       "cxxstd": "11,14,17,2a",     "address-model": "32",    "os": "windows-2025", "target-os": "cygwin"},
-            {"toolset": "gcc",       "cxxstd": "11,14,17,2a",     "address-model": "64",    "os": "windows-2025", "target-os": "cygwin"},
-          ]
-
-          def is_true(env_var):
-              return os.environ.get(env_var).lower() == 'true'
-
-          def filter_multi_valued(in_list, key_name, excluded):
-              """Remove all entries from the value identified by key_name that are contained in excluded (comma-separated).
-                 Omit the entry when the attribute is empty, keep it if the attribute is not present."""
-              excluded_values = {x.strip() for x in excluded.split(',')}
-              for entry in in_list:
-                  try:
-                      values = [x.strip() for x in entry[key_name].split(',')]
-                  except KeyError:
-                      yield entry
-                  else:
-                      remaining_values = [v for v in values if v and v not in excluded_values]
-                      if remaining_values:
-                          entry[key_name] = ",".join(remaining_values)
-                          yield entry
-
-          def filter_os(in_list, excluded):
-              """Remove all jobs that match any of the excluded OS (comma-separated, supports partial matches)"""
-              excluded_values = [v for v in (x.strip().replace('-', ':') for x in excluded.split(',')) if v]
-              return (job for job in in_list if not any(ev in job.get('container', job['os']).replace('-', ':') for ev in excluded_values))
-
-          def filter_yes_values(in_list, key_name):
-              """Remove all entries with value 'yes' for the key"""
-              return (e for e in in_list if not e.get(key_name) == "yes")
-
-          filtered = all_jobs
-          filtered = filter_multi_valued(filtered, 'cxxstd', os.environ['EXCLUDE_CXXSTD'])
-          filtered = filter_multi_valued(filtered, 'toolset', os.environ['EXCLUDE_COMPILER'])
-          filtered = filter_os(filtered, os.environ['EXCLUDE_OS'])
-          if not is_true('ENABLE_32BIT'):
-              filtered = filter_multi_valued(filtered, 'address-model', '32')
-          if not is_true('ENABLE_CYGWIN'):
-              filtered = filter_multi_valued(filtered, 'target-os', 'cygwin')
-
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-              print(f"matrix={json.dumps({'include': list(filtered)})}", file=fh)
-        shell: python
-        env:
-          ENABLE_32BIT: ${{ inputs.enable_32bit }}
+          ENABLE_PR_COVERAGE: ${{ inputs.enable_pr_coverage }}
           ENABLE_CYGWIN: ${{ inputs.enable_cygwin }}
-          EXCLUDE_CXXSTD: ${{ inputs.exclude_cxxstd }}
           EXCLUDE_COMPILER: ${{ inputs.exclude_compiler }}
-          EXCLUDE_OS: ${{ inputs.exclude_os }}
-
-      - id: mingw-matrix
-        name: MinGW
-        if: ${{ inputs.enable_mingw }}
-        run: |
-          import json, os
-
-          all_jobs = [
-              {"sys": "MINGW32", "compiler": "gcc", "cxxstd": "11,17,20"},
-              {"sys": "MINGW64", "compiler": "gcc", "cxxstd": "11,17,20"},
-          ]
-
-          def is_true(env_var):
-              return os.environ.get(env_var).lower() == 'true'
-
-          def filter_multi_valued(in_list, key_name, excluded):
-              """Remove all entries from the value identified by key_name that are contained in excluded (comma-separated).
-                 Omit the entry when the attribute is empty, keep it if the attribute is not present."""
-              excluded_values = {x.strip() for x in excluded.split(',')}
-              for entry in in_list:
-                  try:
-                      values = [x.strip() for x in entry[key_name].split(',')]
-                  except KeyError:
-                      yield entry
-                  else:
-                      remaining_values = [v for v in values if v and v not in excluded_values]
-                      if remaining_values:
-                          entry[key_name] = ",".join(remaining_values)
-                          yield entry
-
-          def filter_os(in_list, excluded):
-              """Remove all jobs that match any of the excluded OS (comma-separated, supports partial matches)"""
-              excluded_values = [v for v in (x.strip().replace('-', ':') for x in excluded.split(',')) if v]
-              return (job for job in in_list if not any(ev in job['sys'] for ev in excluded_values))
-
-          def filter_yes_values(in_list, key_name):
-              """Remove all entries with value 'yes' for the key"""
-              return (e for e in in_list if not e.get(key_name) == "yes")
-
-          filtered = all_jobs
-          filtered = filter_multi_valued(filtered, 'cxxstd', os.environ['EXCLUDE_CXXSTD'])
-          if not is_true('ENABLE_32BIT'):
-              filtered = filter_multi_valued(filtered, 'sys', 'MINGW32')
-
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-              print(f"matrix={json.dumps({'include': list(filtered)})}", file=fh)
-        shell: python
-        env:
-          ENABLE_32BIT: ${{ inputs.enable_32bit }}
           EXCLUDE_CXXSTD: ${{ inputs.exclude_cxxstd }}
-
-      - id: cmake-matrix
-        name: CMake
-        if: ${{ inputs.enable_cmake }}
-        run: |
-          import json, os
-
-          all_jobs = [
-            { "os": "ubuntu-latest",        "build_shared": "ON",  "build_type": "Debug", "generator": "Unix Makefiles" },
-            { "os": "ubuntu-latest",        "build_shared": "OFF", "build_type": "Debug", "generator": "Unix Makefiles" },
-            { "os": "windows-2022",         "build_shared": "ON",  "build_type": "Debug", "generator": "Visual Studio 17 2022" },
-            { "os": "windows-2022",         "build_shared": "OFF", "build_type": "Debug", "generator": "Visual Studio 17 2022" },
-            { "os": "windows-2025-vs2026",  "build_shared": "OFF", "build_type": "Debug", "generator": "Visual Studio 18 2026" },
-            { "name": "Min. CMake", "cmake_version": os.environ["MIN_CMAKE_VERSION"],
-              "os": "ubuntu-latest",            "build_shared": "ON",  "build_type": "Debug", "generator": "Unix Makefiles" },
-          ]
-          filtered = all_jobs
-
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-              print(f"matrix={json.dumps({'include': list(filtered)})}", file=fh)
-        shell: python
-        env:
+          EXCLUDE_OS: ${{ inputs.exclude_os }}
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
           MIN_CMAKE_VERSION: ${{ inputs.min_cmake_version }}
 
   posix:

--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -318,6 +318,8 @@ jobs:
                 {"toolset": "msvc-14.3", "cxxstd": "14,17,20,latest", "address-model": "32,64", "os": "windows-2022"},
                 {"toolset": "msvc-14.5", "cxxstd": "14,17,20,latest", "address-model": "32,64", "os": "windows-2025-vs2026"},
                 {"toolset": "msvc-14.3", "cxxstd": "14,17,20,latest", "address-model": "64", "os": "windows-11-arm"},
+                {"name": "Collect coverage w/ VS 2022", "coverage": "yes",
+                 "toolset": "msvc-14.3", "cxxstd": "latest",          "address-model": "64",    "os": "windows-2022"},
                 {"name": "Collect coverage w/ VS 2026", "coverage": "yes",
                  "toolset": "msvc-14.5", "cxxstd": "latest",          "address-model": "64",    "os": "windows-2025-vs2026"},
                 {"toolset": "clang-win", "cxxstd": "14,17,latest",    "address-model": "32,64", "os": "windows-2025"},


### PR DESCRIPTION
Merge matrix generation steps. - Allow defining filter functions only once.
Use that to filter CMake jobs based on the used generator.

Drive-by fix: `enable_pr_coverage` was ignored due to mistyping: `os.environ.get('$ENABLE_PR_COVERAGE')`